### PR TITLE
chore: rename `ets` to `tsplus`

### DIFF
--- a/effect/src/index.ts
+++ b/effect/src/index.ts
@@ -19,7 +19,7 @@ export const prog = Effect.do
 
 export const result = prog | Effect.fail("error");
 
-prog.unsafeRunPromise();
+prog.unsafeRunPromise()
 
 export const xxx = pipe(0, n => n + 1, n => `hello: ${n}`);
 

--- a/effect/src/prelude/definition/Effect.ts
+++ b/effect/src/prelude/definition/Effect.ts
@@ -1,17 +1,17 @@
 import * as T from "@effect-ts/core/Effect";
 
 /**
- * @ets type ets/Effect
+ * @tsplus type ets/Effect
  */
 export interface Effect<R, E, A> extends T.Effect<R, E, A> { }
 /**
- * @ets type ets/EffectOps
+ * @tsplus type ets/EffectOps
  */
 export interface EffectOps { }
 export const Effect: EffectOps = {};
 
 /**
- * @ets unify ets/Effect
+ * @tsplus unify ets/Effect
  */
 export function unifyEffect<X extends Effect<any, any, any>>(self: X): Effect<
     [X] extends [Effect<infer R, any, any>] ? R : never,

--- a/effect/src/prelude/definition/Maybe.ts
+++ b/effect/src/prelude/definition/Maybe.ts
@@ -8,19 +8,19 @@ export interface Just<A> {
 }
 
 /**
- * @ets type Maybe
+ * @tsplus type Maybe
  */
 export type Maybe<A> = Nothing | Just<A>
 
 /**
- * @ets type MaybeOps
+ * @tsplus type MaybeOps
  */
 export interface MaybeOps { }
 
 export const Maybe: MaybeOps = {}
 
 /**
- * @ets unify Maybe
+ * @tsplus unify Maybe
  */
 export function unifyMaybe<X extends Maybe<any>>(self: X): Maybe<
     [X] extends [Maybe<infer A>] ? A : never
@@ -29,43 +29,43 @@ export function unifyMaybe<X extends Maybe<any>>(self: X): Maybe<
 }
 
 /**
- * @ets static MaybeOps nothing
+ * @tsplus static MaybeOps nothing
  */
 export function nothing(): Maybe<never> {
     return { _tag: "Nothing" }
 }
 
 /**
- * @ets static MaybeOps just
+ * @tsplus static MaybeOps just
  */
 export function just<A>(value: A): Maybe<A> {
     return { _tag: "Just", value }
 }
 
 /**
- * @ets fluent Maybe match
+ * @tsplus fluent Maybe match
  */
 export function match_<A, B, C>(self: Maybe<A>, onNothing: () => B, onJust: (a: A) => C): B | C {
     return self._tag === "Nothing" ? onNothing() : onJust(self.value);
 }
 
 /**
- * @ets operator Maybe +
- * @ets fluent Maybe zip
+ * @tsplus operator Maybe +
+ * @tsplus fluent Maybe zip
  */
 export function zip_<A, B>(self: Maybe<A>, that: Maybe<B>): Maybe<readonly [A, B]> {
     throw new Error("unimplemented")
 }
 
 /**
- * @ets fluent Maybe isJust
+ * @tsplus fluent Maybe isJust
  */
 export function isJust<A>(self: Maybe<A>): self is Just<A> {
     return self._tag === "Just";
 }
 
 /**
- * @ets fluent Maybe assertJust
+ * @tsplus fluent Maybe assertJust
  */
 export function assertJust<A>(self: Maybe<A>): asserts self is Just<A> {
     if(self._tag !== "Just") {
@@ -75,7 +75,7 @@ export function assertJust<A>(self: Maybe<A>): asserts self is Just<A> {
     
 
 // /**
-//  * @ets getter Maybe value
+//  * @tsplus getter Maybe value
 //  */
 // export function get<A>(self: Maybe<A>): A | undefined {
 //     return self._tag === "Just" ? self.value : undefined
@@ -83,5 +83,3 @@ export function assertJust<A>(self: Maybe<A>): asserts self is Just<A> {
 
 export const result = Maybe.just(0).match(() => 0, () => 1)
 export const op = Maybe.just(0) + Maybe.just(1)
-
-// export const x = op.value

--- a/effect/src/prelude/operations/access.ts
+++ b/effect/src/prelude/operations/access.ts
@@ -5,8 +5,8 @@ import { LazyArgument } from "../../utils/LazyArgument.js";
 /**
  * Effectfully accesses the environment of the effect.
  *
- * @ets static ets/EffectOps access
+ * @tsplus static ets/EffectOps access
  */
-export function access<R0, A>(f: (_: R0) => A, __etsTrace?: string): Effect<R0, never, A> {
-    return T.access(f, __etsTrace);
+export function access<R0, A>(f: (_: R0) => A, __tsplusTrace?: string): Effect<R0, never, A> {
+    return T.access(f, __tsplusTrace);
 }

--- a/effect/src/prelude/operations/bind.ts
+++ b/effect/src/prelude/operations/bind.ts
@@ -6,11 +6,11 @@ import { Effect } from "../definition/Effect.js"
 /**
  * Binds an effectful value in a `do` scope
  *
- * @ets fluent ets/Effect bind
+ * @tsplus fluent ets/Effect bind
  */
-export function bind_<R2, E2, R, E, A, K, N extends string>(self: Effect<R2, E2, K>, tag: Exclude<N, keyof K>, f: (_: K) => Effect<R, E, A>, __etsTrace?: string): Effect<R & R2, E | E2, Flat<K & {
+export function bind_<R2, E2, R, E, A, K, N extends string>(self: Effect<R2, E2, K>, tag: Exclude<N, keyof K>, f: (_: K) => Effect<R, E, A>, __tsplusTrace?: string): Effect<R & R2, E | E2, Flat<K & {
     [k in N]: A
 }>> {
     // @ts-expect-error
-    return T.bind_(self, tag, f, __etsTrace)
+    return T.bind_(self, tag, f, __tsplusTrace)
 }

--- a/effect/src/prelude/operations/do.ts
+++ b/effect/src/prelude/operations/do.ts
@@ -4,6 +4,6 @@ import { Effect } from "../definition/Effect.js";
 /**
  * Creates a do context, to be used with bind/let
  *
- * @ets static ets/EffectOps do
+ * @tsplus static ets/EffectOps do
  */
 export const do_: Effect<unknown, never, {}> = T.do;

--- a/effect/src/prelude/operations/failWith.ts
+++ b/effect/src/prelude/operations/failWith.ts
@@ -6,8 +6,8 @@ import { LazyArgument } from "../../utils/LazyArgument.js";
  * Returns an effect that models failure with the specified error.
  * The moral equivalent of `throw` for pure code.
  *
- * @ets static ets/EffectOps fail
+ * @tsplus static ets/EffectOps fail
  */
-export function failWith<E>(e: LazyArgument<E>, __etsTrace?: string): Effect<unknown, E, never> {
-    return T.failWith(e, __etsTrace);
+export function failWith<E>(e: LazyArgument<E>, __tsplusTrace?: string): Effect<unknown, E, never> {
+    return T.failWith(e, __tsplusTrace);
 }

--- a/effect/src/prelude/operations/flatMap.ts
+++ b/effect/src/prelude/operations/flatMap.ts
@@ -6,8 +6,8 @@ import { Effect } from "../definition/Effect.js";
  * the passing of its value to the specified continuation function `f`,
  * followed by the effect that it returns.
  *
- * @ets fluent ets/Effect flatMap
+ * @tsplus fluent ets/Effect flatMap
  */
-export function chain_<R, E, A, R1, E1, A1>(self: Effect<R, E, A>, f: (a: A) => Effect<R1, E1, A1>, __etsTrace?: string): Effect<R & R1, E | E1, A1> {
-    return T.chain_(self, f, __etsTrace);
+export function chain_<R, E, A, R1, E1, A1>(self: Effect<R, E, A>, f: (a: A) => Effect<R1, E1, A1>, __tsplusTrace?: string): Effect<R & R1, E | E1, A1> {
+    return T.chain_(self, f, __tsplusTrace);
 }

--- a/effect/src/prelude/operations/map.ts
+++ b/effect/src/prelude/operations/map.ts
@@ -3,8 +3,8 @@ import { Effect } from "../definition/Effect.js";
 /**
  * Returns an effect whose success is mapped by the specified `f` function.
  *
- * @ets fluent ets/Effect map
+ * @tsplus fluent ets/Effect map
  */
-export function map_<R, E, A, B>(self: Effect<R, E, A>, f: (a: A) => B, __etsTrace?: string): Effect<R, E, B> {
+export function map_<R, E, A, B>(self: Effect<R, E, A>, f: (a: A) => B, __tsplusTrace?: string): Effect<R, E, B> {
     return self.flatMap((a) => Effect.succeed(f(a)));
 }

--- a/effect/src/prelude/operations/orElse.ts
+++ b/effect/src/prelude/operations/orElse.ts
@@ -7,9 +7,9 @@ import { LazyArgument } from "../../utils/LazyArgument.js"
 /**
  * Sequentially zips this effect with the specified effect
  *
- * @ets operator ets/Effect |
- * @ets fluent ets/Effect orElse
+ * @tsplus operator ets/Effect |
+ * @tsplus fluent ets/Effect orElse
  */
-export function orElse_<R, E, A, R2, E2, A2>(self: Effect<R, E, A>, that: LazyArgument<Effect<R2, E2, A2>>, __etsTrace?: string) {
-    return T.orElse_(self, that, __etsTrace)
+export function orElse_<R, E, A, R2, E2, A2>(self: Effect<R, E, A>, that: LazyArgument<Effect<R2, E2, A2>>, __tsplusTrace?: string) {
+    return T.orElse_(self, that, __tsplusTrace)
 }

--- a/effect/src/prelude/operations/run.ts
+++ b/effect/src/prelude/operations/run.ts
@@ -4,8 +4,8 @@ import { Effect } from "../definition/Effect";
 /**
  * Runs an effect as a promise
  *
- * @ets fluent ets/Effect unsafeRunPromise
+ * @tsplus fluent ets/Effect unsafeRunPromise
  */
-export function unsafeRunPromise<E, A>(self: Effect<T.DefaultEnv, E, A>, __etsTrace?: string) {
+export function unsafeRunPromise<E, A>(self: Effect<T.DefaultEnv, E, A>, __tsplusTrace?: string) {
     return T.runPromise(self)
 }

--- a/effect/src/prelude/operations/succeedWith.ts
+++ b/effect/src/prelude/operations/succeedWith.ts
@@ -5,17 +5,17 @@ import { LazyArgument } from "../../utils/LazyArgument.js";
 /**
  * Imports a synchronous side-effect into a pure value
  *
- * @ets static ets/EffectOps succeed
+ * @tsplus static ets/EffectOps succeed
  */
-export function succeedWith<A>(effect: LazyArgument<A>, __etsTrace?: string): Effect<unknown, never, A> {
-    return T.succeedWith(effect, __etsTrace);
+export function succeedWith<A>(effect: LazyArgument<A>, __tsplusTrace?: string): Effect<unknown, never, A> {
+    return T.succeedWith(effect, __tsplusTrace);
 }
 
 /**
  * Imports a synchronous side-effect into a pure value
  *
- * @ets static ets/EffectOps __call
+ * @tsplus static ets/EffectOps __call
  */
-export function effectApply<A>(effect: LazyArgument<A>, __etsTrace?: string): Effect<unknown, never, A> {
-    return T.succeedWith(effect, __etsTrace);
+export function effectApply<A>(effect: LazyArgument<A>, __tsplusTrace?: string): Effect<unknown, never, A> {
+    return T.succeedWith(effect, __tsplusTrace);
 }

--- a/effect/src/prelude/operations/unit.ts
+++ b/effect/src/prelude/operations/unit.ts
@@ -4,6 +4,6 @@ import { Effect } from "../definition/Effect.js";
 /**
  * Returns the effect resulting from mapping the success of this effect to unit.
  *
- * @ets static ets/EffectOps unit
+ * @tsplus static ets/EffectOps unit
  */
 export const unit: Effect<unknown, never, void> = T.unit;

--- a/effect/src/prelude/operations/zip.ts
+++ b/effect/src/prelude/operations/zip.ts
@@ -6,9 +6,9 @@ import { Effect } from "../definition/Effect.js"
 /**
  * Sequentially zips this effect with the specified effect
  *
- * @ets operator ets/Effect +
- * @ets fluent ets/Effect zip
+ * @tsplus operator ets/Effect +
+ * @tsplus fluent ets/Effect zip
  */
-export function zip_<R, E, A, R2, E2, A2>(self: Effect<R, E, A>, that: Effect<R2, E2, A2>, __etsTrace?: string): Effect<R & R2, E | E2, Tp.Tuple<[A, A2]>> {
-    return T.zip_(self, that, __etsTrace)
+export function zip_<R, E, A, R2, E2, A2>(self: Effect<R, E, A>, that: Effect<R2, E2, A2>, __tsplusTrace?: string): Effect<R & R2, E | E2, Tp.Tuple<[A, A2]>> {
+    return T.zip_(self, that, __tsplusTrace)
 }

--- a/effect/src/utils/LazyArgument.ts
+++ b/effect/src/utils/LazyArgument.ts
@@ -1,4 +1,4 @@
 /**
- * @ets type ets/LazyArgument
+ * @tsplus type tsplus/LazyArgument
  */
 export interface LazyArgument<A> { (): A; }

--- a/effect/tsconfig.json
+++ b/effect/tsconfig.json
@@ -9,8 +9,8 @@
         "declarationDir": "build/dts",
         "skipLibCheck": true,
         "lib": ["ES2021"],
-        "etsModuleDiscoveryLocalSuffix": "js",
-        "etsTracingPackageName": "@app"
+        "tsPlusModuleDiscoveryLocalSuffix": "js",
+        "tsPlusTracingPackageName": "@app"
     },
     "include": ["src/**/*.ts"]
 }

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -273,7 +273,7 @@ namespace ts {
         Uncapitalize: IntrinsicTypeKind.Uncapitalize
     }));
 
-    // ETS EXTENSION START
+    // TSPLUS EXTENSION START
     const invertedBinaryOp = {
         [SyntaxKind.LessThanToken]: "<" as __String,
         [SyntaxKind.GreaterThanToken]: ">" as __String,
@@ -299,7 +299,7 @@ namespace ts {
         [SyntaxKind.BarBarToken]: "||" as __String,
         [SyntaxKind.QuestionQuestionToken]: "??" as __String
     } as const;
-    // ETS EXTENSION END
+    // TSPLUS EXTENSION END
 
     function SymbolLinks(this: SymbolLinks) {
     }
@@ -348,7 +348,7 @@ namespace ts {
             return map;
         });
 
-        // ETS EXTENSION START
+        // TSPLUS EXTENSION START
         const importAsCache = new Map<string, string>();
         const typeSymbolCache = new Map<Symbol, string>();
         const fluentCache = new Map<string, ESMap<string, { patched: Symbol, definition: SourceFile, exportName: string }>>();
@@ -357,7 +357,7 @@ namespace ts {
         const staticCache = new Map<string, ESMap<string, { patched: Symbol, definition: SourceFile, exportName: string }>>();
         const identityCache = new Map<string, FunctionDeclaration>();
         const callCache = new Map<Node, { patched: Symbol, definition: SourceFile, exportName: string }>();
-        // ETS EXTENSION END
+        // TSPLUS EXTENSION END
 
         // Cancellation that controls whether or not we can cancel in the middle of type checking.
         // In general cancelling is *not* safe for the type checker.  We might be in the middle of
@@ -774,7 +774,7 @@ namespace ts {
             isPropertyAccessible,
             getTypeOnlyAliasDeclaration,
             getMemberOverrideModifierStatus,
-            // ETS EXTENSION BEGIN
+            // TSPLUS EXTENSION BEGIN
             getGlobalImport,
             getLocalImport,
             getExtensions,
@@ -785,14 +785,14 @@ namespace ts {
             getCallExtension,
             shouldMakeLazy,
             isPipeCall
-            // ETS EXTENSION END
+            // TSPLUS EXTENSION END
         };
 
-        // ETS EXTENSION BEGIN
+        // TSPLUS EXTENSION BEGIN
         function isPipeCall(node: CallExpression) {
             const type = getTypeOfNode(node.expression);
             if (type.symbol) {
-                return (type.symbol.declarations || []).flatMap(collectEtsMacroTags).filter((tag) => tag.comment === "macro pipe").length > 0;
+                return (type.symbol.declarations || []).flatMap(collectTsPlusMacroTags).filter((tag) => tag.comment === "macro pipe").length > 0;
             }
             return false;
         }
@@ -805,8 +805,8 @@ namespace ts {
                 const types = (type as UnionType).types;
                 const lazyArg = types.find((type) => {
                     if (type.symbol) {
-                        const tag = type.symbol.declarations?.flatMap(collectEtsTypeTags)[0];
-                        if (tag?.comment === "type ets/LazyArgument") {
+                        const tag = type.symbol.declarations?.flatMap(collectTsPlusTypeTags)[0];
+                        if (tag?.comment === "type tsplus/LazyArgument") {
                             return true;
                         }
                     }
@@ -900,7 +900,7 @@ namespace ts {
                 }
             }
         }
-        // ETS EXTENSION END
+        // TSPLUS EXTENSION END
 
         function getResolvedSignatureWorker(nodeIn: CallLikeExpression, candidatesOutArray: Signature[] | undefined, argumentCount: number | undefined, checkMode: CheckMode): Signature | undefined {
             const node = getParseTreeNode(nodeIn, isCallLikeExpression);
@@ -14527,8 +14527,8 @@ namespace ts {
             return result;
         }
 
-        // ETS EXTENSION START
-        function checkEtsCustomCall(
+        // TSPLUS EXTENSION START
+        function checkTsPlusCustomCall(
             declaration: Declaration,
             args: Expression[],
             checkMode: CheckMode | undefined,
@@ -14541,15 +14541,15 @@ namespace ts {
             candidate.parameters = candidate.parameters.map((p) => {
                 const type = getTypeOfSymbol(p);
                 if (type.symbol) {
-                    const tag = type.symbol.declarations?.flatMap(collectEtsTypeTags)[0];
-                    if (tag?.comment === "type ets/LazyArgument") {
+                    const tag = type.symbol.declarations?.flatMap(collectTsPlusTypeTags)[0];
+                    if (tag?.comment === "type tsplus/LazyArgument") {
                         return createSymbolWithType(p, getUnionType([type, (type as TypeReference).resolvedTypeArguments![0]]));
                     }
                 }
                 return p;
             })
             const node = factory.createCallExpression(
-                factory.createIdentifier("$ets_custom_call"),
+                factory.createIdentifier("$tsplus_custom_call"),
                 [],
                 args
             );
@@ -14617,7 +14617,7 @@ namespace ts {
             if (targetSymbol) {
                 const declaration = targetSymbol.declarations?.[0];
                 if (declaration) {
-                    const typeTag = collectEtsTypeTags(declaration)[0];
+                    const typeTag = collectTsPlusTypeTags(declaration)[0];
                     if (typeTag) {
                         const target = typeTag.comment.split(" ")[1]!;
                         if (target) {
@@ -14628,7 +14628,7 @@ namespace ts {
                                         return unionType;
                                     }
                                 }
-                                const result = checkEtsCustomCall(
+                                const result = checkTsPlusCustomCall(
                                     id,
                                     [factory.createSyntheticExpression(getUnionTypeOriginal(types, unionReduction, aliasSymbol, aliasTypeArguments, origin))],
                                     CheckMode.Normal
@@ -14643,7 +14643,7 @@ namespace ts {
             }
             return unionType;
         }
-        // ETS EXTENSION END
+        // TSPLUS EXTENSION END
 
         // We sort and deduplicate the constituent types based on object identity. If the subtypeReduction
         // flag is specified we also reduce the constituent type set to only include types that aren't subtypes
@@ -25397,7 +25397,7 @@ namespace ts {
             return getTypeOfSymbol(symbol);
         }
 
-        // ETS EXTENSION START
+        // TSPLUS EXTENSION START
         function checkIdentifier(node: Identifier, checkMode: CheckMode | undefined): Type {
             const type = checkIdentifierOriginal(node, checkMode);
             // We should only mark aliases as referenced if there isn't a local value declaration
@@ -25410,7 +25410,7 @@ namespace ts {
             }
             return type;
         }
-        // ETS EXTENSION END
+        // TSPLUS EXTENSION END
 
         function checkIdentifierOriginal(node: Identifier, checkMode: CheckMode | undefined): Type {
             const symbol = getResolvedSymbol(node);
@@ -28699,7 +28699,7 @@ namespace ts {
                 && getThisContainer(node, /*includeArrowFunctions*/ true) === getDeclaringConstructor(prop);
         }
 
-        // ETS EXTENSION START
+        // TSPLUS EXTENSION START
         function checkPropertyAccessForExtension(node: PropertyAccessExpression | QualifiedName, _left: Expression | QualifiedName, leftType: Type, right: Identifier | PrivateIdentifier, _checkMode: CheckMode | undefined) {
             const inType = getPropertiesOfType(leftType).findIndex((p) => p.escapedName === right.escapedText) !== -1;
             if (!inType) {
@@ -28712,7 +28712,7 @@ namespace ts {
                     const symbol = getterExt.patched(leftType)
                     if (symbol) {
                         const type = getTypeOfSymbol(symbol);
-                        type.symbol = symbol; // EtsGetterSymbol | EtsGetterVariableSymbol
+                        type.symbol = symbol; // TsPlusGetterSymbol | TsPlusGetterVariableSymbol
                         return type;
                     }
                 }
@@ -28722,15 +28722,15 @@ namespace ts {
                 }
             }
         }
-        // ETS EXTENSION END
+        // TSPLUS EXTENSION END
 
         function checkPropertyAccessExpressionOrQualifiedName(node: PropertyAccessExpression | QualifiedName, left: Expression | QualifiedName, leftType: Type, right: Identifier | PrivateIdentifier, checkMode: CheckMode | undefined) {
-            // ETS EXTENSION START
+            // TSPLUS EXTENSION START
             const forExtension = checkPropertyAccessForExtension(node, left, leftType, right, checkMode);
             if (forExtension) {
                 return forExtension;
             }
-            // ETS EXTENSION END
+            // TSPLUS EXTENSION END
             const parentSymbol = getNodeLinks(left).resolvedSymbol;
             const assignmentKind = getAssignmentTargetKind(node);
             const apparentType = getApparentType(assignmentKind !== AssignmentKind.None || isMethodAccessForCall(node) ? getWidenedType(leftType) : leftType);
@@ -30776,7 +30776,7 @@ namespace ts {
             
             let callSignatures = getSignaturesOfType(apparentType, SignatureKind.Call);
 
-            // ETS EXTENSION START
+            // TSPLUS EXTENSION START
             if (callSignatures.length === 0) {
                 const callExtension = getStaticExtension(apparentType, "__call");
                 
@@ -30789,8 +30789,8 @@ namespace ts {
                 s.parameters = s.parameters.map((p) => {
                     const type = getTypeOfSymbol(p);
                     if (type.symbol) {
-                        const tag = type.symbol.declarations?.flatMap(collectEtsTypeTags)[0];
-                        if (tag?.comment === "type ets/LazyArgument") {
+                        const tag = type.symbol.declarations?.flatMap(collectTsPlusTypeTags)[0];
+                        if (tag?.comment === "type tsplus/LazyArgument") {
                             return createSymbolWithType(p, getUnionType([type, (type as TypeReference).resolvedTypeArguments![0]]));
                         }
                     }
@@ -30798,7 +30798,7 @@ namespace ts {
                 });
                 return s;
             })
-            // ETS EXTENSION END
+            // TSPLUS EXTENSION END
 
             const numConstructSignatures = getSignaturesOfType(apparentType, SignatureKind.Construct).length;
 
@@ -31850,8 +31850,8 @@ namespace ts {
 
         function isLazyParameter(type: Type) {
             if (type.symbol && type.symbol.declarations && type.symbol.declarations.length > 0) {
-                const tag = collectEtsTypeTags(type.symbol.declarations[0])[0];
-                if (tag && tag.comment === "type ets/LazyArgument") {
+                const tag = collectTsPlusTypeTags(type.symbol.declarations[0])[0];
+                if (tag && tag.comment === "type tsplus/LazyArgument") {
                     return true;
                 }
             }
@@ -33380,7 +33380,7 @@ namespace ts {
             const trampoline = createBinaryExpressionTrampoline(onEnter, onLeft, onOperator, onRight, onExit, foldState);
 
             return (node: BinaryExpression, checkMode: CheckMode | undefined) => {
-                // ETS EXTENSION START
+                // TSPLUS EXTENSION START
                 const leftType = getTypeOfNode(node.left);
                 // @ts-expect-error
                 const operator = invertedBinaryOp[node.operatorToken.kind] as string | undefined
@@ -33389,7 +33389,7 @@ namespace ts {
                     if (operatorOverload) {
                         const declaration = operatorOverload.patched.declarations?.find(isFunctionDeclaration);
                         if (declaration) {
-                            return checkEtsCustomCall(
+                            return checkTsPlusCustomCall(
                                 declaration as FunctionDeclaration,
                                 [node.left, node.right],
                                 checkMode,
@@ -33398,7 +33398,7 @@ namespace ts {
                         }
                     }
                 }
-                // ETS EXTENSION END
+                // TSPLUS EXTENSION END
                 const result = trampoline(node, checkMode);
                 Debug.assertIsDefined(result);
                 return result;
@@ -42753,10 +42753,10 @@ namespace ts {
             return getDeclarationOfKind(moduleSymbol, SyntaxKind.SourceFile);
         }
 
-        // ETS EXTENSION START
+        // TSPLUS EXTENSION START
         function getLocalImport(from: SourceFile, file: SourceFile) {
             // TODO(Mike):
-            return compilerOptions.etsModuleDiscoveryLocalSuffix ?
+            return compilerOptions.tsPlusModuleDiscoveryLocalSuffix ?
                 (getRelativePathFromFile(from.fileName, file.fileName, normalizePath).replace(/\.(ts|tsx)$/, "") + ".js") :
                 getRelativePathFromFile(from.fileName, file.fileName, normalizePath).replace(/((\/|\\)index)?\.(ts|tsx)$/, "");
         }
@@ -42776,8 +42776,8 @@ namespace ts {
                 if (host.fileExists(path)) {
                     try {
                         const content = JSON.parse(host.readFile(path)!);
-                        const packageName = content.ets?.packageName || content.name;
-                        const typeDir = content.ets?.typeDir ? `${dir}/${content.ets?.typeDir}` : dir;
+                        const packageName = content.tsplus?.packageName || content.name;
+                        const typeDir = content.tsplus?.typeDir ? `${dir}/${content.tsplus?.typeDir}` : dir;
                         if (packageName && typeDir) {
                             // TODO(Mike): Improve this to make sure it works across systems
                             let importAs = packageName + "/" + getRelativePathFromDirectory(
@@ -42799,50 +42799,49 @@ namespace ts {
             throw new Error("unreachable")
         }
 
-        // ETS EXTENSION START
-        function collectEtsFluentTags(statement: Declaration) {
+        function collectTsPlusFluentTags(statement: Declaration) {
             return getAllJSDocTags(
                 statement,
-                (tag): tag is JSDocEtsExtensionTag => tag.tagName.escapedText === "ets" && typeof tag.comment === "string" && tag.comment.startsWith("fluent")
+                (tag): tag is TsPlusJSDocExtensionTag => tag.tagName.escapedText === "tsplus" && typeof tag.comment === "string" && tag.comment.startsWith("fluent")
             );
         }
-        function collectEtsTypeTags(statement: Declaration) {
+        function collectTsPlusTypeTags(statement: Declaration) {
             return getAllJSDocTags(
                 statement,
-                (tag): tag is JSDocEtsTypeTag => tag.tagName.escapedText === "ets" && typeof tag.comment === "string" && tag.comment.startsWith("type")
+                (tag): tag is TsPlusJSDocTypeTag => tag.tagName.escapedText === "tsplus" && typeof tag.comment === "string" && tag.comment.startsWith("type")
             );
         }
-        function collectEtsMacroTags(statement: Declaration) {
+        function collectTsPlusMacroTags(statement: Declaration) {
             return getAllJSDocTags(
                 statement,
-                (tag): tag is JSDocEtsMacroTag => tag.tagName.escapedText === "ets" && typeof tag.comment === "string" && tag.comment.startsWith("macro")
+                (tag): tag is TsPlusJSDocMacroTag => tag.tagName.escapedText === "tsplus" && typeof tag.comment === "string" && tag.comment.startsWith("macro")
             );
         }
-        function collectEtsUnifyTags(statement: Declaration) {
+        function collectTsPlusUnifyTags(statement: Declaration) {
             return getAllJSDocTags(
                 statement,
-                (tag): tag is JSDocEtsUnifyTag => tag.tagName.escapedText === "ets" && typeof tag.comment === "string" && tag.comment.startsWith("unify")
+                (tag): tag is TsPlusJSDocUnifyTag => tag.tagName.escapedText === "tsplus" && typeof tag.comment === "string" && tag.comment.startsWith("unify")
             );
         }
-        function collectEtsStaticTags(statement: Node) {
+        function collectTsPlusStaticTags(statement: Node) {
             return getAllJSDocTags(
                 statement,
-                (tag): tag is JSDocEtsStaticTag => tag.tagName.escapedText === "ets" && typeof tag.comment === "string" && tag.comment.startsWith("static")
+                (tag): tag is TsPlusJSDocStaticTag => tag.tagName.escapedText === "tsplus" && typeof tag.comment === "string" && tag.comment.startsWith("static")
             );
         }
-        function collectEtsOperatorTags(statement: Node) {
+        function collectTsPlusOperatorTags(statement: Node) {
             return getAllJSDocTags(
                 statement,
-                (tag): tag is JSDocEtsOperatorTag => tag.tagName.escapedText === "ets" && typeof tag.comment === "string" && tag.comment.startsWith("operator")
+                (tag): tag is TsPlusJSDocOperatorTag => tag.tagName.escapedText === "tsplus" && typeof tag.comment === "string" && tag.comment.startsWith("operator")
             );
         }
-        function collectEtsGetterTags(statement: Node) {
+        function collectTsPlusGetterTags(statement: Node) {
             return getAllJSDocTags(
                 statement,
-                (tag): tag is JSDocEtsOperatorTag => tag.tagName.escapedText === "ets" && typeof tag.comment === "string" && tag.comment.startsWith("getter")
+                (tag): tag is TsPlusJSDocOperatorTag => tag.tagName.escapedText === "tsplus" && typeof tag.comment === "string" && tag.comment.startsWith("getter")
             );
         }
-        function etsThisifySignature(call: Signature) {
+        function thisifyTsPlusSignature(call: Signature) {
             const signature = cloneSignature(call);
             const target = signature.parameters[0];
             signature.thisParameter = createSymbolWithType(createSymbol(target.flags, "this" as __String), getTypeOfSymbol(target));
@@ -42860,36 +42859,36 @@ namespace ts {
             signature.instantiations = call.instantiations;
             return signature;
         }
-        function createEtsFluentFunctionSymbol(name: string, dataFirst: FunctionDeclaration, signatures: Signature[]): EtsFluentSymbol {
-            const symbol = createSymbol(SymbolFlags.Function, name as __String) as EtsFluentSymbol;
-            symbol.etsTag = EtsSymbolTag.Fluent;
-            symbol.etsDeclaration = dataFirst;
-            symbol.etsResolvedSignatures = signatures;
+        function createTsPlusFluentFunctionSymbol(name: string, dataFirst: FunctionDeclaration, signatures: Signature[]): TsPlusFluentSymbol {
+            const symbol = createSymbol(SymbolFlags.Function, name as __String) as TsPlusFluentSymbol;
+            symbol.tsPlusTag = TsPlusSymbolTag.Fluent;
+            symbol.tsPlusDeclaration = dataFirst;
+            symbol.tsPlusResolvedSignatures = signatures;
             return symbol;
         }
-        function createEtsFluentVariableSymbol(name: string, declaration: VariableDeclaration & { name: Identifier }, signatures: Signature[]): EtsFluentVariableSymbol {
-            const symbol = createSymbol(SymbolFlags.Function, name as __String) as EtsFluentVariableSymbol;
-            symbol.etsTag = EtsSymbolTag.FluentVariable;
-            symbol.etsDeclaration = declaration;
-            symbol.etsResolvedSignatures = signatures as SignatureWithParameters[];
+        function createTsPlusFluentVariableSymbol(name: string, declaration: VariableDeclaration & { name: Identifier }, signatures: Signature[]): TsPlusFluentVariableSymbol {
+            const symbol = createSymbol(SymbolFlags.Function, name as __String) as TsPlusFluentVariableSymbol;
+            symbol.tsPlusTag = TsPlusSymbolTag.FluentVariable;
+            symbol.tsPlusDeclaration = declaration;
+            symbol.tsPlusResolvedSignatures = signatures as SignatureWithParameters[];
             return symbol;
         }
-        function createEtsGetterVariableSymbol(name: string, dataFirst: VariableDeclaration & { name: Identifier }, returnType: Type, selfType: Type) {
-            const symbol = createSymbol(SymbolFlags.Property, name as __String) as EtsGetterVariableSymbol;
+        function createTsPlusGetterVariableSymbol(name: string, dataFirst: VariableDeclaration & { name: Identifier }, returnType: Type, selfType: Type) {
+            const symbol = createSymbol(SymbolFlags.Property, name as __String) as TsPlusGetterVariableSymbol;
             symbol.type = returnType;
-            symbol.etsTag = EtsSymbolTag.GetterVariable;
-            symbol.etsDeclaration = dataFirst;
-            symbol.etsSelfType = selfType;
+            symbol.tsPlusTag = TsPlusSymbolTag.GetterVariable;
+            symbol.tsPlusDeclaration = dataFirst;
+            symbol.tsPlusSelfType = selfType;
             return symbol;
         }
-        function createEtsStaticFunctionSymbol(name: string, dataFirst: FunctionDeclaration, signatures: Signature[]): EtsStaticSymbol {
-            const symbol = createSymbol(SymbolFlags.Function, name as __String) as EtsStaticSymbol;
-            symbol.etsTag = EtsSymbolTag.Static;
-            symbol.etsDeclaration = dataFirst;
-            symbol.etsResolvedSignatures = signatures;
+        function createTsPlusStaticFunctionSymbol(name: string, dataFirst: FunctionDeclaration, signatures: Signature[]): TsPlusStaticSymbol {
+            const symbol = createSymbol(SymbolFlags.Function, name as __String) as TsPlusStaticSymbol;
+            symbol.tsPlusTag = TsPlusSymbolTag.Static;
+            symbol.tsPlusDeclaration = dataFirst;
+            symbol.tsPlusResolvedSignatures = signatures;
             return symbol;
         }
-        function createEtsStaticVariableSymbol(name: string, declaration: VariableDeclaration, originalSymbol: Symbol): Symbol {
+        function createTsPlusStaticVariableSymbol(name: string, declaration: VariableDeclaration, originalSymbol: Symbol): Symbol {
             const symbol = cloneSymbol(originalSymbol);
             symbol.escapedName = name as __String;
             const patchedDeclaration = factory.updateVariableDeclaration(
@@ -42901,41 +42900,41 @@ namespace ts {
             );
             setParent(patchedDeclaration, declaration.parent);
             setParent(patchedDeclaration.name, patchedDeclaration)
-            patchedDeclaration.name.etsName = name;
+            patchedDeclaration.name.tsPlusName = name;
             symbol.declarations = [patchedDeclaration];
             symbol.valueDeclaration = patchedDeclaration;
             patchedDeclaration.jsDoc = getJSDocCommentsAndTags(declaration) as JSDoc[];
             return symbol;
         }
-        function createEtsGetterFunctionSymbol(name: string, dataFirst: FunctionDeclaration, returnType: Type, selfType: Type) {
-            const symbol = createSymbol(SymbolFlags.Property, name as __String) as EtsGetterSymbol;
+        function createTsPlusGetterFunctionSymbol(name: string, dataFirst: FunctionDeclaration, returnType: Type, selfType: Type) {
+            const symbol = createSymbol(SymbolFlags.Property, name as __String) as TsPlusGetterSymbol;
             symbol.type = returnType;
-            symbol.etsTag = EtsSymbolTag.Getter;
-            symbol.etsDeclaration = dataFirst;
-            symbol.etsSelfType = selfType;
+            symbol.tsPlusTag = TsPlusSymbolTag.Getter;
+            symbol.tsPlusDeclaration = dataFirst;
+            symbol.tsPlusSelfType = selfType;
             return symbol;
         }
-        function getEtsFluentSymbolForFunctionDeclaration(name: string, dataFirst: FunctionDeclaration) {
+        function getTsPlusFluentSymbolForFunctionDeclaration(name: string, dataFirst: FunctionDeclaration) {
             const type = getTypeOfNode(dataFirst);
             const signatures = getSignaturesOfType(type, SignatureKind.Call);
-            const methods = signatures.map(etsThisifySignature);
-            const symbol = createEtsFluentFunctionSymbol(name, dataFirst, methods) as EtsFluentSymbol;
+            const methods = signatures.map(thisifyTsPlusSignature);
+            const symbol = createTsPlusFluentFunctionSymbol(name, dataFirst, methods) as TsPlusFluentSymbol;
             const final = createAnonymousType(symbol, emptySymbols, methods, [], []);
             return createSymbolWithType(symbol, final);
         }
-        function getEtsFluentSymbolForVariableDeclaration(name: string, declaration: VariableDeclaration & { name: Identifier }) {
+        function getTsPlusFluentSymbolForVariableDeclaration(name: string, declaration: VariableDeclaration & { name: Identifier }) {
             const type = getTypeOfNode(declaration);
             const signatures = getSignaturesOfType(type, SignatureKind.Call);
             if(signatures.every((sigSymbol) => sigSymbol.parameters.every((paramSymbol) => paramSymbol.valueDeclaration && isVariableLike(paramSymbol.valueDeclaration) && isParameterDeclaration(paramSymbol.valueDeclaration)))) {
-                const methods = signatures.map(etsThisifySignature);
-                const symbol = createEtsFluentVariableSymbol(name, declaration, methods);
+                const methods = signatures.map(thisifyTsPlusSignature);
+                const symbol = createTsPlusFluentVariableSymbol(name, declaration, methods);
                 const final = createAnonymousType(symbol, emptySymbols, methods, [], []);
                 return createSymbolWithType(symbol, final);
             }
         }
-        function getEtsGetterSymbolForFunctionDeclaration(_name: string, _dataFirst: FunctionDeclaration) {
+        function getTsPlusGetterSymbolForFunctionDeclaration(_name: string, _dataFirst: FunctionDeclaration) {
             return (self: Type) => {
-                const res = checkEtsCustomCall(
+                const res = checkTsPlusCustomCall(
                     _dataFirst,
                     [factory.createSyntheticExpression(self)],
                     CheckMode.Normal
@@ -42943,12 +42942,12 @@ namespace ts {
                 if (isErrorType(res)) {
                     return void 0;
                 }
-                return createEtsGetterFunctionSymbol(_name, _dataFirst, res, self);
+                return createTsPlusGetterFunctionSymbol(_name, _dataFirst, res, self);
             }
         }
-        function getEtsGetterSymbolForVariableDeclaration(name: string, declaration: VariableDeclaration & { name: Identifier }) {
+        function getTsPlusGetterSymbolForVariableDeclaration(name: string, declaration: VariableDeclaration & { name: Identifier }) {
             return (self: Type) => {
-                const res = checkEtsCustomCall(
+                const res = checkTsPlusCustomCall(
                     declaration,
                     [factory.createSyntheticExpression(self)],
                     CheckMode.Normal
@@ -42956,18 +42955,18 @@ namespace ts {
                 if (isErrorType(res)) {
                     return void 0;
                 }
-                return createEtsGetterVariableSymbol(name, declaration, res, self);
+                return createTsPlusGetterVariableSymbol(name, declaration, res, self);
             }
         }
-        function getEtsStaticSymbolForFunctionDeclaration(name: string, dataFirst: FunctionDeclaration) {
+        function getTsPlusStaticSymbolForFunctionDeclaration(name: string, dataFirst: FunctionDeclaration) {
             const signatures = getSignaturesOfType(getTypeOfNode(dataFirst), SignatureKind.Call);
             const methods = signatures.map(cloneSignature);
-            const symbol = createEtsStaticFunctionSymbol(name, dataFirst, methods);
+            const symbol = createTsPlusStaticFunctionSymbol(name, dataFirst, methods);
             const final = createAnonymousType(symbol, emptySymbols, methods, [], []);
             return createSymbolWithType(symbol, final);
         }
-        function tryCacheEtsType(declaration: InterfaceDeclaration | TypeAliasDeclaration): void {
-            const tag = collectEtsTypeTags(declaration)[0];
+        function tryCacheTsPlusType(declaration: InterfaceDeclaration | TypeAliasDeclaration): void {
+            const tag = collectTsPlusTypeTags(declaration)[0];
             if (tag) {
                 const type = getTypeOfNode(declaration);
                 if (type.symbol) {
@@ -42978,8 +42977,8 @@ namespace ts {
                 }
             }
         }
-        function tryCacheEtsStaticVariable(file: SourceFile, statement: VariableStatement) {
-            const staticTag = collectEtsStaticTags(statement)[0];
+        function tryCacheTsPlusStaticVariable(file: SourceFile, statement: VariableStatement) {
+            const staticTag = collectTsPlusStaticTags(statement)[0];
             if (staticTag) {
                 const [, target, name] = staticTag.comment.split(" ");
                 if (!staticCache.has(target)) {
@@ -42989,7 +42988,7 @@ namespace ts {
                 const declaration = statement.declarationList.declarations[0];
                 const symbol = getSymbolAtLocation(declaration.name);
                 if (symbol) {
-                    const patched = createEtsStaticVariableSymbol(name, declaration, symbol);
+                    const patched = createTsPlusStaticVariableSymbol(name, declaration, symbol);
                     map.set(name, {
                         patched,
                         definition: file,
@@ -42998,17 +42997,17 @@ namespace ts {
                 }
             }
         }
-        function tryCacheEtsFluentVariable(file: SourceFile, statement: VariableStatement) {
+        function tryCacheTsPlusFluentVariable(file: SourceFile, statement: VariableStatement) {
             if (statement.declarationList.declarations.length === 1) {
                 const declaration = statement.declarationList.declarations[0]
                 if(isIdentifier(declaration.name)) {
-                    const fluentTag = collectEtsFluentTags(declaration)[0];
+                    const fluentTag = collectTsPlusFluentTags(declaration)[0];
                     if(fluentTag) {
                         const [, target, name] = fluentTag.comment.split(" ");
                         if (!fluentCache.has(target)) {
                             fluentCache.set(target, new Map());
                         }
-                        const patched = getEtsFluentSymbolForVariableDeclaration(
+                        const patched = getTsPlusFluentSymbolForVariableDeclaration(
                             name,
                             (declaration as VariableDeclaration & { name: Identifier })
                         )
@@ -43024,11 +43023,11 @@ namespace ts {
                 }
             }
         }
-        function tryCacheEtsGetterVariable(file: SourceFile, statement: VariableStatement) {
+        function tryCacheTsPlusGetterVariable(file: SourceFile, statement: VariableStatement) {
             if (statement.declarationList.declarations.length === 1) {
                 const declaration = statement.declarationList.declarations[0]
                 if (isIdentifier(declaration.name)) {
-                    const getterTag = collectEtsGetterTags(declaration)[0];
+                    const getterTag = collectTsPlusGetterTags(declaration)[0];
                     if (getterTag) {
                         const [, target, name] = getterTag.comment.split(" ");
                         if (!getterCache.has(target)) {
@@ -43039,7 +43038,7 @@ namespace ts {
                         }
                         const map = getterCache.get(target)!;
                         map.set(name, {
-                            patched: getEtsGetterSymbolForVariableDeclaration(
+                            patched: getTsPlusGetterSymbolForVariableDeclaration(
                                 name,
                                 (declaration as VariableDeclaration & { name: Identifier })
                             ),
@@ -43050,9 +43049,9 @@ namespace ts {
                 }
             }
         }
-        function tryCacheEtsOperatorFunction(file: SourceFile, declaration: FunctionDeclaration) {
+        function tryCacheTsPlusOperatorFunction(file: SourceFile, declaration: FunctionDeclaration) {
             if(declaration.name && isIdentifier(declaration.name)) {
-                const operatorTag = collectEtsOperatorTags(declaration)[0];
+                const operatorTag = collectTsPlusOperatorTags(declaration)[0];
                 if (operatorTag) {
                     const symbol = getSymbolAtLocation(declaration.name)
                     if (symbol) {
@@ -43070,9 +43069,9 @@ namespace ts {
                 }
             }
         }
-        function tryCacheEtsFluentFunction(file: SourceFile, declaration: FunctionDeclaration) {
+        function tryCacheTsPlusFluentFunction(file: SourceFile, declaration: FunctionDeclaration) {
             if(declaration.name && isIdentifier(declaration.name)) {
-                const fluentTag = collectEtsFluentTags(declaration)[0];
+                const fluentTag = collectTsPlusFluentTags(declaration)[0];
                 if (fluentTag) {
                     const [, target, name] = fluentTag.comment.split(" ");
                     if (!fluentCache.has(target)) {
@@ -43080,16 +43079,16 @@ namespace ts {
                     }
                     const map = fluentCache.get(target)!;
                     map.set(name, {
-                        patched: getEtsFluentSymbolForFunctionDeclaration(name, declaration),
+                        patched: getTsPlusFluentSymbolForFunctionDeclaration(name, declaration),
                         exportName: declaration.name.escapedText.toString(),
                         definition: file
                     });
                 }
             }
         }
-        function tryCacheEtsGetterFunction(file: SourceFile, declaration: FunctionDeclaration) {
+        function tryCacheTsPlusGetterFunction(file: SourceFile, declaration: FunctionDeclaration) {
             if(declaration.name && isIdentifier(declaration.name)) {
-                const getterTag = collectEtsGetterTags(declaration)[0];
+                const getterTag = collectTsPlusGetterTags(declaration)[0];
                 if (getterTag) {
                     const [, target, name] = getterTag.comment.split(" ");
                     if (!getterCache.has(target)) {
@@ -43097,16 +43096,16 @@ namespace ts {
                     }
                     const map = getterCache.get(target)!;
                     map.set(name, {
-                        patched: getEtsGetterSymbolForFunctionDeclaration(name, declaration),
+                        patched: getTsPlusGetterSymbolForFunctionDeclaration(name, declaration),
                         exportName: declaration.name.escapedText.toString(),
                         definition: file
                     });
                 }
             }
         }
-        function tryCacheEtsStaticFunction(file: SourceFile, declaration: FunctionDeclaration) {
+        function tryCacheTsPlusStaticFunction(file: SourceFile, declaration: FunctionDeclaration) {
             if(declaration.name && isIdentifier(declaration.name)) {
-                const staticTag = collectEtsStaticTags(declaration)[0];
+                const staticTag = collectTsPlusStaticTags(declaration)[0];
                 if (staticTag) {
                     const [, target, name] = staticTag.comment.split(" ");
                     if (!staticCache.has(target)) {
@@ -43114,47 +43113,47 @@ namespace ts {
                     }
                     const map = staticCache.get(target)!;
                     map.set(name, {
-                        patched: getEtsStaticSymbolForFunctionDeclaration(name, declaration),
+                        patched: getTsPlusStaticSymbolForFunctionDeclaration(name, declaration),
                         exportName: declaration.name.escapedText.toString(),
                         definition: file
                     });
                 }
             }
         }
-        function tryCacheEtsUnifyFunction(declaration: FunctionDeclaration) {
+        function tryCacheTsPlusUnifyFunction(declaration: FunctionDeclaration) {
             if(declaration.name && isIdentifier(declaration.name)) {
-                const unifyTag = collectEtsUnifyTags(declaration)[0];
+                const unifyTag = collectTsPlusUnifyTags(declaration)[0];
                 if (unifyTag) {
                     const [, target] = unifyTag.comment.split(" ");
                     identityCache.set(target, declaration);
                 }
             }
         }
-        function collectEtsSymbols(file: SourceFile, statements: NodeArray<Statement>): void {
+        function collectTsPlusSymbols(file: SourceFile, statements: NodeArray<Statement>): void {
             for (const statement of statements) {
                 if(statement.modifiers && findIndex(statement.modifiers, t => t.kind === SyntaxKind.ExportKeyword) !== -1) {
                     if (isInterfaceDeclaration(statement) || isTypeAliasDeclaration(statement)) {
-                        tryCacheEtsType(statement)
+                        tryCacheTsPlusType(statement)
                     }
                     if (isModuleDeclaration(statement) && statement.body && isModuleBlock(statement.body)) {
-                        collectEtsSymbols(file, statement.body.statements)
+                        collectTsPlusSymbols(file, statement.body.statements)
                     }
                     if (isVariableStatement(statement) && statement.declarationList.declarations.length === 1) {
-                        tryCacheEtsStaticVariable(file, statement);
-                        tryCacheEtsFluentVariable(file, statement);
-                        tryCacheEtsGetterVariable(file, statement);
+                        tryCacheTsPlusStaticVariable(file, statement);
+                        tryCacheTsPlusFluentVariable(file, statement);
+                        tryCacheTsPlusGetterVariable(file, statement);
                     }
                     if (isFunctionDeclaration(statement)) {
-                        tryCacheEtsOperatorFunction(file, statement);
-                        tryCacheEtsStaticFunction(file, statement);
-                        tryCacheEtsFluentFunction(file, statement);
-                        tryCacheEtsGetterFunction(file, statement);
-                        tryCacheEtsUnifyFunction(statement);
+                        tryCacheTsPlusOperatorFunction(file, statement);
+                        tryCacheTsPlusStaticFunction(file, statement);
+                        tryCacheTsPlusFluentFunction(file, statement);
+                        tryCacheTsPlusGetterFunction(file, statement);
+                        tryCacheTsPlusUnifyFunction(statement);
                     }
                 }
             }
         }
-        function etsInitTypeChecker() {
+        function initTsPlusTypeChecker() {
             fluentCache.clear();
             operatorCache.clear();
             typeSymbolCache.clear();
@@ -43163,10 +43162,10 @@ namespace ts {
             getterCache.clear();
             callCache.clear();
             for (const file of host.getSourceFiles()) {
-                collectEtsSymbols(file, file.statements)
+                collectTsPlusSymbols(file, file.statements)
             }
         }
-        // ETS EXTENSION END
+        // TSPLUS EXTENSION END
 
         function initializeTypeChecker() {
             // Bind all source files and propagate errors
@@ -43298,7 +43297,7 @@ namespace ts {
                 }
             });
             amalgamatedDuplicates = undefined;
-            etsInitTypeChecker();
+            initTsPlusTypeChecker();
         }
 
         function checkExternalEmitHelpers(location: Node, helpers: ExternalEmitHelpers) {
@@ -45129,9 +45128,9 @@ namespace ts {
     export function signatureHasLiteralTypes(s: Signature) {
         return !!(s.flags & SignatureFlags.HasLiteralTypes);
     }
-    // ETS EXTENSION BEGIN
-    export function isEtsSymbol(symbol: Symbol): symbol is EtsSymbol {
-        return 'etsTag' in symbol;
+    // TSPLUS EXTENSION BEGIN
+    export function isTsPlusSymbol(symbol: Symbol): symbol is TsPlusSymbol {
+        return 'tsPlusTag' in symbol;
     }
     export function getNameForType(type: Type | undefined): string | undefined {
         if(!type) {
@@ -45144,25 +45143,25 @@ namespace ts {
             return type.aliasSymbol.escapedName as string;
         }
     }
-    export function getThisTypeNameForEtsSymbol(symbol: EtsSymbol): string {
-        switch(symbol.etsTag) {
-            case EtsSymbolTag.FluentVariable:
-            case EtsSymbolTag.Fluent: {
-                if(symbol.etsResolvedSignatures[0] && symbol.etsResolvedSignatures[0].thisParameter) {
-                    return getNameForType((symbol.etsResolvedSignatures[0].thisParameter as TransientSymbol).type) || "<anonymous>";
+    export function getThisTypeNameForTsPlusSymbol(symbol: TsPlusSymbol): string {
+        switch(symbol.tsPlusTag) {
+            case TsPlusSymbolTag.FluentVariable:
+            case TsPlusSymbolTag.Fluent: {
+                if(symbol.tsPlusResolvedSignatures[0] && symbol.tsPlusResolvedSignatures[0].thisParameter) {
+                    return getNameForType((symbol.tsPlusResolvedSignatures[0].thisParameter as TransientSymbol).type) || "<anonymous>";
                 }
                 break;
             }
-            case EtsSymbolTag.GetterVariable:
-            case EtsSymbolTag.Getter: {
-                return getNameForType(symbol.etsSelfType) || "<anonymous>";
+            case TsPlusSymbolTag.GetterVariable:
+            case TsPlusSymbolTag.Getter: {
+                return getNameForType(symbol.tsPlusSelfType) || "<anonymous>";
             }
-            case EtsSymbolTag.Static: {
+            case TsPlusSymbolTag.Static: {
                 // Statics do not have a `this` type
                 break;
             }
         }
         return "<anonymous>";
     }
-    // ETS EXTENSION END
+    // TSPLUS EXTENSION END
 }

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -42966,12 +42966,6 @@ namespace ts {
             const final = createAnonymousType(symbol, emptySymbols, methods, [], []);
             return createSymbolWithType(symbol, final);
         }
-        function getEtsStaticSymbolForVariableDeclaration(name: string, declaration: VariableDeclaration) {
-            const symbol = getSymbolAtLocation(declaration.name);
-            if (symbol) {
-                return createEtsStaticVariableSymbol(name, declaration, symbol)
-            }
-        }
         function tryCacheEtsType(declaration: InterfaceDeclaration | TypeAliasDeclaration): void {
             const tag = collectEtsTypeTags(declaration)[0];
             if (tag) {
@@ -42992,12 +42986,14 @@ namespace ts {
                     staticCache.set(target, new Map());
                 }
                 const map = staticCache.get(target)!;
-                const patched = getEtsStaticSymbolForVariableDeclaration(name, statement.declarationList.declarations[0]);
-                if (patched) {
+                const declaration = statement.declarationList.declarations[0];
+                const symbol = getSymbolAtLocation(declaration.name);
+                if (symbol) {
+                    const patched = createEtsStaticVariableSymbol(name, declaration, symbol);
                     map.set(name, {
                         patched,
                         definition: file,
-                        exportName: patched.escapedName.toString()
+                        exportName: symbol.escapedName.toString()
                     })
                 }
             }

--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -198,11 +198,11 @@ namespace ts {
             defaultValueDescription: false,
         },
         {
-            name: "etsModuleDiscoveryLocalSuffix",
+            name: "tsPlusModuleDiscoveryLocalSuffix",
             type: "string"
         },
         {
-            name: "etsTracingPackageName",
+            name: "tsPlusTracingPackageName",
             type: "string"
         },
         {

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -1967,7 +1967,7 @@ namespace ts {
 
             const emitTransformers = getTransformers(options, customTransformers, emitOnlyDtsFiles);
             const patchedTransformers: EmitTransformers = {
-                scriptTransformers: [transformETS(checker, options, host), ...emitTransformers.scriptTransformers],
+                scriptTransformers: [transformTsPlus(checker, options, host), ...emitTransformers.scriptTransformers],
                 declarationTransformers: emitTransformers.declarationTransformers
             }
             const emitResult = emitFiles(

--- a/src/compiler/transformers/tsplus.ts
+++ b/src/compiler/transformers/tsplus.ts
@@ -1,19 +1,19 @@
 /*@internal*/
 namespace ts {
-    class EtsImporter {
+    class TsPlusImporter {
         readonly imports: ESMap<string, Identifier> = new Map();
         constructor(readonly factory: NodeFactory) { }
 
         get(path: string): Identifier {
             if (!this.imports.has(path)) {
-                this.imports.set(path, this.factory.createUniqueName("ets_module"));
+                this.imports.set(path, this.factory.createUniqueName("tsplus_module"));
             }
             return this.imports.get(path)!;
         }
     }
-    export function transformETS(checker: TypeChecker, options: CompilerOptions, host: CompilerHost) {
+    export function transformTsPlus(checker: TypeChecker, options: CompilerOptions, host: CompilerHost) {
         return function (context: TransformationContext) {
-            const importer = new EtsImporter(context.factory);
+            const importer = new TsPlusImporter(context.factory);
             const fileVar = factory.createUniqueName("fileName");
             let fileVarUsed = false;
             return chainBundle(context, transformSourceFile);
@@ -50,7 +50,7 @@ namespace ts {
                                     undefined,
                                     undefined,
                                     factory.createStringLiteral(
-                                        (options.etsTracingPackageName ? options.etsTracingPackageName + ":" : "") +
+                                        (options.tsPlusTracingPackageName ? options.tsPlusTracingPackageName + ":" : "") +
                                         (options.configFilePath ? getRelativePathFromFile(options.configFilePath, node.fileName, host.getCanonicalFileName).replace(/^\.(\\|\/)/, "") : node.fileName)
                                     )
                                 )
@@ -101,7 +101,7 @@ namespace ts {
                 if (operator) {
                     const type = checker.getTypeOfSymbol(operator.patched)
                     const call = checker.getSignaturesOfType(type, SignatureKind.Call)[0];
-                    const lastTrace = call.parameters.length > 0 ? call.parameters[call.parameters.length - 1].escapedName === "___etsTrace" : false
+                    const lastTrace = call.parameters.length > 0 ? call.parameters[call.parameters.length - 1].escapedName === "___tsplusTrace" : false
                     const params = [visitNode(node.left, visitor(source, traceInScope)), visitNode(node.right, visitor(source, traceInScope))]
                     if (checker.shouldMakeLazy(call.parameters[1], checker.getTypeAtLocation(node.right))) {
                         params[1] = context.factory.createArrowFunction(void 0, void 0, [], void 0, void 0, params[1]);
@@ -122,7 +122,7 @@ namespace ts {
                     const last = node.parameters[node.parameters.length - 1]
 
                     if (last.name.kind === SyntaxKind.Identifier) {
-                        if ((last.name as Identifier).escapedText === "___etsTrace") {
+                        if ((last.name as Identifier).escapedText === "___tsplusTrace") {
                             return visitEachChild(node, visitor(source, last.name as Identifier), context)
                         }
                     }
@@ -225,7 +225,7 @@ namespace ts {
                         }
                     }
                     if (newArgs.length === params.length - 1) {
-                        if (params[params.length - 1].escapedName === "___etsTrace") {
+                        if (params[params.length - 1].escapedName === "___tsplusTrace") {
                             if (traceInScope) {
                                 newArgs.push(traceInScope);
                             } else {
@@ -243,7 +243,7 @@ namespace ts {
                 return visitEachChild(node, visitor, context);
             }
         }
-        function getPathOfExtension(factory: NodeFactory, importer: EtsImporter, extension: { definition: SourceFile; exportName: string; }, source: SourceFile) {
+        function getPathOfExtension(factory: NodeFactory, importer: TsPlusImporter, extension: { definition: SourceFile; exportName: string; }, source: SourceFile) {
             if (source.fileName === extension.definition.fileName) {
                 return factory.createIdentifier(extension.exportName);
             }

--- a/src/compiler/tsconfig.json
+++ b/src/compiler/tsconfig.json
@@ -59,7 +59,7 @@
         "transformers/es2016.ts",
         "transformers/es2015.ts",
         "transformers/es5.ts",
-        "transformers/eff.ts",
+        "transformers/tsplus.ts",
         "transformers/generators.ts",
         "transformers/module/module.ts",
         "transformers/module/system.ts",

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -868,7 +868,7 @@ namespace ts {
         /* @internal */ emitNode?: EmitNode;                  // Associated EmitNode (initialized by transforms)
         /* @internal */ contextualType?: Type;                // Used to temporarily assign a contextual type during overload resolution
         /* @internal */ inferenceContext?: InferenceContext;  // Inference context for contextual type
-        /* @internal */ etsName?: string;
+        /* @internal */ tsPlusName?: string;
     }
 
     export interface JSDocContainer {
@@ -3259,95 +3259,95 @@ namespace ts {
         readonly comment?: string | NodeArray<JSDocComment>;
     }
 
-    export interface JSDocEtsTypeTag extends JSDocTag {
+    export interface TsPlusJSDocTypeTag extends JSDocTag {
         readonly parent: JSDoc | JSDocTypeLiteral;
         readonly tagName: Identifier;
         readonly comment: `type ${string}`
     }
 
-    export interface JSDocEtsUnifyTag extends JSDocTag {
+    export interface TsPlusJSDocUnifyTag extends JSDocTag {
         readonly parent: JSDoc | JSDocTypeLiteral;
         readonly tagName: Identifier;
         readonly comment: `unify ${string}`
     }
 
-    export interface JSDocEtsExtensionTag extends JSDocTag {
+    export interface TsPlusJSDocExtensionTag extends JSDocTag {
         readonly parent: JSDoc | JSDocTypeLiteral;
         readonly tagName: Identifier;
         readonly comment: `fluent ${string} ${string}`
     }
     
-    export interface JSDocEtsGetterTag extends JSDocTag {
+    export interface TsPlusJSDocGetterTag extends JSDocTag {
         readonly parent: JSDoc | JSDocTypeLiteral;
         readonly tagName: Identifier;
         readonly comment: `getter ${string} ${string}`
     }
 
-    export interface JSDocEtsStaticTag extends JSDocTag {
+    export interface TsPlusJSDocStaticTag extends JSDocTag {
         readonly parent: JSDoc | JSDocTypeLiteral;
         readonly tagName: Identifier;
         readonly comment: `static ${string} ${string}`
     }
 
-    export interface JSDocEtsOperatorTag extends JSDocTag {
+    export interface TsPlusJSDocOperatorTag extends JSDocTag {
         readonly parent: JSDoc | JSDocTypeLiteral;
         readonly tagName: Identifier;
         readonly comment: `operator ${string} ${string}`
     }
 
-    export interface JSDocEtsMacroTag extends JSDocTag {
+    export interface TsPlusJSDocMacroTag extends JSDocTag {
         readonly parent: JSDoc | JSDocTypeLiteral;
         readonly tagName: Identifier;
         readonly comment: `macro ${string}`
     }
 
-    export const enum EtsSymbolTag {
-        Fluent = "EtsFluentSymbol",
-        FluentVariable = "EtsFluentVariableSymbol",
-        Static = "EtsStaticSymbol",
-        Getter = "EtsGetterSymbol",
-        GetterVariable = "EtsGetterVariableSymbol"
+    export const enum TsPlusSymbolTag {
+        Fluent = "TsPlusFluentSymbol",
+        FluentVariable = "TsPlusFluentVariableSymbol",
+        Static = "TsPlusStaticSymbol",
+        Getter = "TsPlusGetterSymbol",
+        GetterVariable = "TsPlusGetterVariableSymbol"
     }
 
-    export interface EtsFluentSymbol extends TransientSymbol {
-        etsTag: EtsSymbolTag.Fluent
-        etsDeclaration: FunctionDeclaration;
-        etsResolvedSignatures: Signature[];
+    export interface TsPlusFluentSymbol extends TransientSymbol {
+        tsPlusTag: TsPlusSymbolTag.Fluent
+        tsPlusDeclaration: FunctionDeclaration;
+        tsPlusResolvedSignatures: Signature[];
     }
 
     export type SignatureWithParameters = Omit<Signature, "parameters"> & { parameters: ReadonlyArray<Symbol & { valueDeclaration: ParameterDeclaration }> }
 
-    export interface EtsFluentVariableSymbol extends TransientSymbol {
-        etsTag: EtsSymbolTag.FluentVariable;
-        etsDeclaration: VariableDeclaration & { name: Identifier };
-        etsParameters: ReadonlyArray<ParameterDeclaration>;
-        etsResolvedSignatures: SignatureWithParameters[];
+    export interface TsPlusFluentVariableSymbol extends TransientSymbol {
+        tsPlusTag: TsPlusSymbolTag.FluentVariable;
+        tsPlusDeclaration: VariableDeclaration & { name: Identifier };
+        tsPlusParameters: ReadonlyArray<ParameterDeclaration>;
+        tsPlusResolvedSignatures: SignatureWithParameters[];
     }
 
-    export interface EtsStaticSymbol extends TransientSymbol {
-        etsTag: EtsSymbolTag.Static;
-        etsDeclaration: FunctionDeclaration;
-        etsResolvedSignatures: Signature[];
+    export interface TsPlusStaticSymbol extends TransientSymbol {
+        tsPlusTag: TsPlusSymbolTag.Static;
+        tsPlusDeclaration: FunctionDeclaration;
+        tsPlusResolvedSignatures: Signature[];
     }
 
-    export interface EtsGetterSymbol extends TransientSymbol {
-        etsTag: EtsSymbolTag.Getter;
-        etsSelfType: Type;
-        etsDeclaration: FunctionDeclaration;
+    export interface TsPlusGetterSymbol extends TransientSymbol {
+        tsPlusTag: TsPlusSymbolTag.Getter;
+        tsPlusSelfType: Type;
+        tsPlusDeclaration: FunctionDeclaration;
     }
 
-    export interface EtsGetterVariableSymbol extends TransientSymbol {
-        etsTag: EtsSymbolTag.GetterVariable;
-        etsDeclaration: VariableDeclaration & { name: Identifier };
-        etsSelfType: Type;
+    export interface TsPlusGetterVariableSymbol extends TransientSymbol {
+        tsPlusTag: TsPlusSymbolTag.GetterVariable;
+        tsPlusDeclaration: VariableDeclaration & { name: Identifier };
+        tsPlusSelfType: Type;
     }
 
-    export type EtsSymbol =
-        | EtsFluentSymbol
-        | EtsStaticSymbol
-        | EtsGetterSymbol
-        | EtsFluentVariableSymbol
-        | EtsGetterVariableSymbol;
+    export type TsPlusSymbol =
+        | TsPlusFluentSymbol
+        | TsPlusStaticSymbol
+        | TsPlusGetterSymbol
+        | TsPlusFluentVariableSymbol
+        | TsPlusGetterVariableSymbol;
 
     export interface JSDocLink extends Node {
         readonly kind: SyntaxKind.JSDocLink;
@@ -3753,7 +3753,7 @@ namespace ts {
         /* @internal */ exportedModulesFromDeclarationEmit?: ExportedModulesFromDeclarationEmit;
         /* @internal */ endFlowNode?: FlowNode;
 
-        etsImportAs?: () => string | undefined
+        tsPlusImportAs?: () => string | undefined
     }
 
     /* @internal */
@@ -6276,8 +6276,8 @@ namespace ts {
 
         [option: string]: CompilerOptionsValue | TsConfigSourceFile | undefined;
 
-        etsModuleDiscoveryLocalSuffix?: "js"
-        etsTracingPackageName?: string
+        tsPlusModuleDiscoveryLocalSuffix?: "js"
+        tsPlusTracingPackageName?: string
     }
 
     export interface WatchOptions {

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -964,8 +964,8 @@ namespace ts {
     // Computed property names will just be emitted as "[<expr>]", where <expr> is the source
     // text of the expression in the computed property.
     export function declarationNameToString(name: DeclarationName | QualifiedName | undefined) {
-        if (name?.etsName) {
-            return name?.etsName;
+        if (name?.tsPlusName) {
+            return name?.tsPlusName;
         }
         return !name || getFullWidth(name) === 0 ? "(Missing)" : getTextOfNode(name);
     }

--- a/src/lib/es5.d.ts
+++ b/src/lib/es5.d.ts
@@ -4473,7 +4473,7 @@ interface Date {
 }
 
 /**
- * @ets macro pipe
+ * @tsplus macro pipe
  */
 declare function pipe<A>(a: A): A;
 declare function pipe<A, B>(a: A, ab: (a: A) => B): B;

--- a/src/services/goToDefinition.ts
+++ b/src/services/goToDefinition.ts
@@ -39,13 +39,13 @@ namespace ts.GoToDefinition {
             });
         }
 
-        // BEGIN ETS EXTENSION
+        // TSPLUS EXTENSION BEGIN
         let symbol: Symbol | undefined;
 
         if(isPropertyAccessExpression(parent)) {
             const nodeType = typeChecker.getTypeAtLocation(node);
-            if(nodeType.symbol && isEtsSymbol(nodeType.symbol)) {
-                symbol = nodeType.symbol.etsDeclaration.symbol;
+            if(nodeType.symbol && isTsPlusSymbol(nodeType.symbol)) {
+                symbol = nodeType.symbol.tsPlusDeclaration.symbol;
             } else {
                 const type = typeChecker.getTypeAtLocation(parent.expression);
                 const extensions = typeChecker.getExtensions(type);
@@ -70,7 +70,7 @@ namespace ts.GoToDefinition {
         if(!symbol) {
             symbol = getSymbol(node, typeChecker);
         }
-        // END ETS EXTENSION
+        // TSPLUS EXTENSION END
 
         // Could not find a symbol e.g. node is string or number keyword,
         // or the symbol was an internal symbol and does not have a declaration e.g. undefined symbol

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -1678,34 +1678,34 @@ namespace ts {
             return Completions.getCompletionEntrySymbol(program, log, getValidSourceFile(fileName), position, { name, source }, host, preferences);
         }
 
-        // ETS EXTENSION BEGIN
-        function getUntracedDisplayParts(typeChecker: TypeChecker, node: Node, symbol: EtsStaticSymbol | EtsFluentSymbol | EtsFluentVariableSymbol): SymbolDisplayPart[] {
-            const declaration = symbol.etsDeclaration;
-            const resolvedSignature = symbol.etsResolvedSignatures[0];
+        // TSPLUS EXTENSION BEGIN
+        function getUntracedDisplayParts(typeChecker: TypeChecker, node: Node, symbol: TsPlusStaticSymbol | TsPlusFluentSymbol | TsPlusFluentVariableSymbol): SymbolDisplayPart[] {
+            const declaration = symbol.tsPlusDeclaration;
+            const resolvedSignature = symbol.tsPlusResolvedSignatures[0];
             const paramLength = resolvedSignature.parameters.length
             const lastParam = resolvedSignature.parameters[paramLength - 1]
-            if(resolvedSignature && lastParam && lastParam.name === "__etsTrace") {
+            if(resolvedSignature && lastParam && lastParam.name === "__tsplusTrace") {
                 let untracedDeclaration: FunctionDeclaration
-                if(symbol.etsTag === EtsSymbolTag.FluentVariable) {
+                if(symbol.tsPlusTag === TsPlusSymbolTag.FluentVariable) {
                     untracedDeclaration = factory.createFunctionDeclaration(
-                        symbol.etsDeclaration.decorators,
-                        symbol.etsDeclaration.modifiers,
+                        symbol.tsPlusDeclaration.decorators,
+                        symbol.tsPlusDeclaration.modifiers,
                         undefined,
-                        symbol.etsDeclaration.name,
+                        symbol.tsPlusDeclaration.name,
                         undefined,
-                        symbol.etsResolvedSignatures[0].parameters.map((s) => s.valueDeclaration).slice(0, paramLength - 1),
-                        symbol.etsDeclaration.type,
+                        symbol.tsPlusResolvedSignatures[0].parameters.map((s) => s.valueDeclaration).slice(0, paramLength - 1),
+                        symbol.tsPlusDeclaration.type,
                         undefined
                     )
                 } else {
                     untracedDeclaration = factory.createFunctionDeclaration(
-                        symbol.etsDeclaration.decorators,
-                        symbol.etsDeclaration.modifiers,
-                        symbol.etsDeclaration.asteriskToken,
-                        symbol.etsDeclaration.name,
-                        symbol.etsDeclaration.typeParameters,
-                        symbol.etsDeclaration.parameters.slice(0, symbol.etsDeclaration.parameters.length - 1),
-                        symbol.etsDeclaration.type,
+                        symbol.tsPlusDeclaration.decorators,
+                        symbol.tsPlusDeclaration.modifiers,
+                        symbol.tsPlusDeclaration.asteriskToken,
+                        symbol.tsPlusDeclaration.name,
+                        symbol.tsPlusDeclaration.typeParameters,
+                        symbol.tsPlusDeclaration.parameters.slice(0, symbol.tsPlusDeclaration.parameters.length - 1),
+                        symbol.tsPlusDeclaration.type,
                         undefined
                     );
                 }
@@ -1732,7 +1732,7 @@ namespace ts {
                 )
             }
         }
-        // ETS EXTENSION END
+        // TSPLUS EXTENSION END
 
         function getQuickInfoAtPosition(fileName: string, position: number): QuickInfo | undefined {
             synchronizeHostData();
@@ -1748,18 +1748,18 @@ namespace ts {
             const nodeForQuickInfo = getNodeForQuickInfo(node);
             const symbol = getSymbolAtLocationForQuickInfo(nodeForQuickInfo, typeChecker);
 
-            // ETS EXTENSION BEGIN
+            // TSPLUS EXTENSION BEGIN
             const call = typeChecker.getCallExtension(nodeForQuickInfo)
             if(call) {
                 const symbol = typeChecker.getTypeOfSymbol(call.patched).symbol
-                if(isEtsSymbol(symbol) && symbol.etsTag === EtsSymbolTag.Static) {
+                if(isTsPlusSymbol(symbol) && symbol.tsPlusTag === TsPlusSymbolTag.Static) {
                     let displayParts: SymbolDisplayPart[] = []
                     displayParts.push(textPart("("));
                     displayParts.push(textPart("call"));
                     displayParts.push(textPart(")"));
                     displayParts.push(spacePart());
                     displayParts = displayParts.concat(getUntracedDisplayParts(typeChecker, nodeForQuickInfo, symbol));
-                    const declaration = symbol.etsDeclaration;
+                    const declaration = symbol.tsPlusDeclaration;
                     return {
                         kind: ScriptElementKind.memberFunctionElement,
                         kindModifiers: ScriptElementKindModifier.none,
@@ -1770,26 +1770,26 @@ namespace ts {
                     };
                 }
             }
-            // ETS EXTENSION END
+            // TSPLUS EXTENSION END
 
             if (!symbol || typeChecker.isUnknownSymbol(symbol)) {
                 const type = shouldGetType(sourceFile, nodeForQuickInfo, position) ? typeChecker.getTypeAtLocation(nodeForQuickInfo) : undefined;
-                // ETS EXTENSION BEGIN
-                if(type && type.symbol && isEtsSymbol(type.symbol)) {
+                // TSPLUS EXTENSION BEGIN
+                if(type && type.symbol && isTsPlusSymbol(type.symbol)) {
                     let displayParts: SymbolDisplayPart[] = []
-                    switch(type.symbol.etsTag) {
-                        case EtsSymbolTag.FluentVariable:
-                        case EtsSymbolTag.Fluent: {
+                    switch(type.symbol.tsPlusTag) {
+                        case TsPlusSymbolTag.FluentVariable:
+                        case TsPlusSymbolTag.Fluent: {
                             displayParts.push(textPart("("));
                             displayParts.push(textPart("fluent"));
                             displayParts.push(textPart(")"));
                             displayParts.push(spacePart());
-                            displayParts.push(displayPart(getThisTypeNameForEtsSymbol(type.symbol), SymbolDisplayPartKind.className));
+                            displayParts.push(displayPart(getThisTypeNameForTsPlusSymbol(type.symbol), SymbolDisplayPartKind.className));
                             displayParts.push(punctuationPart(SyntaxKind.DotToken));
                             displayParts.push(displayPart(type.symbol.escapedName as string, SymbolDisplayPartKind.methodName));
                             break;
                         }
-                        case EtsSymbolTag.Static: {
+                        case TsPlusSymbolTag.Static: {
                             displayParts.push(textPart("("));
                             displayParts.push(textPart("static"));
                             displayParts.push(textPart(")"));
@@ -1797,13 +1797,13 @@ namespace ts {
                             displayParts.push(displayPart(type.symbol.escapedName as string, SymbolDisplayPartKind.methodName));
                             break;
                         }
-                        case EtsSymbolTag.GetterVariable:
-                        case EtsSymbolTag.Getter: {
+                        case TsPlusSymbolTag.GetterVariable:
+                        case TsPlusSymbolTag.Getter: {
                             displayParts.push(textPart("("));
                             displayParts.push(textPart("getter"));
                             displayParts.push(textPart(")"));
                             displayParts.push(spacePart());
-                            displayParts.push(displayPart(getThisTypeNameForEtsSymbol(type.symbol), SymbolDisplayPartKind.className));
+                            displayParts.push(displayPart(getThisTypeNameForTsPlusSymbol(type.symbol), SymbolDisplayPartKind.className));
                             displayParts.push(punctuationPart(SyntaxKind.DotToken));
                             displayParts.push(displayPart(type.symbol.name, SymbolDisplayPartKind.fieldName));
                             displayParts.push(punctuationPart(SyntaxKind.ColonToken));
@@ -1811,12 +1811,12 @@ namespace ts {
                             break;
                         }
                     }
-                    switch(type.symbol.etsTag) {
-                        case EtsSymbolTag.FluentVariable:
-                        case EtsSymbolTag.Fluent:
-                        case EtsSymbolTag.Static: {
+                    switch(type.symbol.tsPlusTag) {
+                        case TsPlusSymbolTag.FluentVariable:
+                        case TsPlusSymbolTag.Fluent:
+                        case TsPlusSymbolTag.Static: {
                             const symbol = type.symbol;
-                            const declaration = symbol.etsDeclaration;
+                            const declaration = symbol.tsPlusDeclaration;
                             displayParts = displayParts.concat(getUntracedDisplayParts(typeChecker, nodeForQuickInfo, symbol));
                             return {
                                 kind: ScriptElementKind.memberFunctionElement,
@@ -1827,16 +1827,16 @@ namespace ts {
                                 tags: getJsDocTagsOfDeclarations([declaration], typeChecker)
                             };
                         }
-                        case EtsSymbolTag.GetterVariable:
-                        case EtsSymbolTag.Getter: {
+                        case TsPlusSymbolTag.GetterVariable:
+                        case TsPlusSymbolTag.Getter: {
                             displayParts = displayParts.concat(typeChecker.runWithCancellationToken(cancellationToken, typeChecker => typeToDisplayParts(typeChecker, type, getContainerNode(nodeForQuickInfo))));
                             return {
                                 kind: ScriptElementKind.memberGetAccessorElement,
                                 kindModifiers: ScriptElementKindModifier.none,
                                 textSpan: createTextSpanFromNode(nodeForQuickInfo, sourceFile),
                                 displayParts,
-                                documentation: getDocumentationComment([type.symbol.etsDeclaration], typeChecker),
-                                tags: getJsDocTagsOfDeclarations([type.symbol.etsDeclaration], typeChecker)
+                                documentation: getDocumentationComment([type.symbol.tsPlusDeclaration], typeChecker),
+                                tags: getJsDocTagsOfDeclarations([type.symbol.tsPlusDeclaration], typeChecker)
                             }
                         }
                     }
@@ -1877,7 +1877,7 @@ namespace ts {
                         }
                     }
                 }
-                // ETS EXTENSION END
+                // TSPLUS EXTENSION END
                 return type && {
                     kind: ScriptElementKind.unknown,
                     kindModifiers: ScriptElementKindModifier.none,

--- a/src/services/signatureHelp.ts
+++ b/src/services/signatureHelp.ts
@@ -79,12 +79,12 @@ namespace ts.SignatureHelp {
                 }
                 let candidates: Signature[] = [];
                 let resolvedSignature = checker.getResolvedSignatureForSignatureHelp(invocation.node, candidates, argumentCount)!; // TODO: GH#18217
-                // BEGIN: ___etsTrace overload
+                // TSPLUS EXTENSION BEGIN
                 if(resolvedSignature.declaration && isFunctionDeclaration(resolvedSignature.declaration)) {
                     const declaration = resolvedSignature.declaration;
                     const lastParam = declaration.parameters[declaration.parameters.length - 1];
                     const parameterCount = resolvedSignature.thisParameter ? declaration.parameters.length - 1 : declaration.parameters.length;
-                    if(declaration.name && lastParam && isIdentifier(lastParam.name) && lastParam.name.escapedText.toString() === "___etsTrace" && argumentCount < parameterCount) {
+                    if(declaration.name && lastParam && isIdentifier(lastParam.name) && lastParam.name.escapedText.toString() === "___tsplusTrace" && argumentCount < parameterCount) {
                         const untracedDeclaration = factory.createFunctionDeclaration(
                             declaration.decorators,
                             declaration.modifiers,
@@ -111,7 +111,7 @@ namespace ts.SignatureHelp {
                         candidates = [untracedSignature];
                     }
                 }
-                // END: ___etsTrace overload
+                // TSPLUS EXTENSION END
                 return candidates.length === 0 ? undefined : { kind: CandidateOrTypeKind.Candidate, candidates, resolvedSignature };
             }
             case InvocationKind.TypeArgs: {


### PR DESCRIPTION
Closes #11 

This PR re-brands all instances of `ets` to `tsplus`. It also includes the fix from #13, but I figured I would put that PR up separately, just in case