### PR TITLE
Implement `@tsplus tailrec` + improve language service features

### DIFF
--- a/effect/src/index.ts
+++ b/effect/src/index.ts
@@ -30,3 +30,15 @@ const y = x.isJust() ? x.value : undefined;
 x.assertJust();
 
 const z = x.value;
+
+
+
+
+
+
+
+
+
+
+
+Effect.fail(0)

--- a/effect/src/tailrec.ts
+++ b/effect/src/tailrec.ts
@@ -1,0 +1,46 @@
+import * as C from "@effect-ts/core/Effect/Cause"
+import * as L from "@effect-ts/core/Collections/Immutable/List"
+import * as O from '@effect-ts/core/Option'
+
+/**
+ * @tsplus tailRec
+ */
+function fac (x: number, acc = 1): number {
+    if (x === 0) {
+        return acc;
+    }
+    return fac (x - 1, x * acc)
+}
+
+/**
+ * @tsplus tailRec
+ */
+ function findLoop <A, B>(
+    cause: C.Cause<A>,
+    f: (cause: C.Cause<A>) => O.Option<B>,
+    stack: L.List<C.Cause<A>>
+  ): O.Option<B> {
+    const r = f(cause)
+    switch (r._tag) {
+      case "None": {
+        switch (cause._tag) {
+          case "Both":
+          case "Then": {
+            return findLoop(cause.left, f, L.prepend_(stack, cause.right))
+          }
+          case "Traced": {
+            return findLoop(cause.cause, f, stack)
+          }
+          default: {
+            if (!L.isEmpty(stack)) {
+              return findLoop(L.unsafeFirst(stack)!, f, L.tail(stack))
+            }
+            return O.none
+          }
+        }
+      }
+      case "Some": {
+        return O.some(r.value)
+      }
+    }
+  }

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -784,7 +784,8 @@ namespace ts {
             getStaticExtension,
             getCallExtension,
             shouldMakeLazy,
-            isPipeCall
+            isPipeCall,
+            isTailRec
             // TSPLUS EXTENSION END
         };
 
@@ -798,6 +799,9 @@ namespace ts {
         }
         function getCallExtension(node: Node) {
             return callCache.get(node);
+        }
+        function isTailRec(node: FunctionDeclaration) {
+            return getAllJSDocTags(node, (tag): tag is JSDocTag => tag.tagName?.escapedText === "tsplus" && tag.comment === "tailRec")[0] !== undefined;
         }
         function shouldMakeLazy(signatureParam: Symbol, callArg: Type) {
             const type = getTypeOfParameterOriginal(signatureParam);
@@ -36545,8 +36549,109 @@ namespace ts {
             forEach(node.decorators, checkDecorator);
         }
 
+        function checkTailRecFunction(node: FunctionDeclaration): void {
+            if (node.body) {
+                checkTailRecFunctionParameters(node.parameters);
+                const paramSymbols = flatMap(node.parameters, (param) => getSymbolsOfBindingName(param.name))
+                forEach(node.body.statements, (s) => {
+                    visitEachChild(
+                        s,
+                        checkTailRecFunctionVisitor(node, paramSymbols),
+                        nullTransformationContext
+                    )
+                })
+            }
+            visitEachChild(
+                node,
+                checkTailRecFunctionVisitor(
+                    node,
+                    flatMap(node.parameters, (param) => getSymbolsOfBindingName(param.name))
+                ),
+                nullTransformationContext
+            );
+        }
+        function checkTailRecFunctionParameters(params: NodeArray<ParameterDeclaration>): void {
+            forEach(params, (param) => {
+                if (!isIdentifier(param.name)) {
+                    error(param, Diagnostics.Parameter_destructuring_is_not_allowed_in_a_tailRec_annotated_function)
+                }
+            })
+        }
+        function checkTailRecFunctionVisitor(functionNode: FunctionDeclaration, parameterSymbols: ReadonlyArray<Symbol>) {
+            return function (node: Node): VisitResult<Node> {
+                if (isReturnStatement(node) && node.expression) {
+                    return visitEachChild(
+                        node,
+                        checkTailRecReturnStatement(functionNode, parameterSymbols),
+                        nullTransformationContext
+                    )
+                }
+                else if (isFunctionDeclaration(node) || isArrowFunction(node)) {
+                    return visitEachChild(
+                        node,
+                        checkTailRecNestedFunction(functionNode),
+                        nullTransformationContext
+                    )
+                }
+                else {
+                    return visitEachChild(
+                        node,
+                        checkTailRecFunctionVisitor(functionNode, parameterSymbols),
+                        nullTransformationContext
+                    );
+                }
+            }
+        }
+        function getSymbolsOfBindingName(node: BindingName): ReadonlyArray<Symbol> {
+            if (isIdentifier(node)) {
+                const symbol = getSymbolAtLocation(node);
+                return symbol ? [symbol] : [];
+            }
+            else if (isObjectBindingPattern(node)) {
+                return flatMap(node.elements, (param) => getSymbolsOfBindingName(param.name));
+            }
+            else {
+                return flatMap(node.elements, (param) => isBindingElement(param) ? getSymbolsOfBindingName(param.name) : undefined);
+            }
+        }
+
+        function checkTailRecNestedFunction(functionNode: FunctionDeclaration) {
+            return function(node: Node): VisitResult<Node> {
+                const funcNameSymbol = getSymbolAtLocation(functionNode.name!);
+                if (isCallExpression(node) && isIdentifier(node.expression)) {
+                    const callNameSymbol = getSymbolAtLocation(node.expression);
+                    if (callNameSymbol === funcNameSymbol) {
+                        error(node, Diagnostics.A_recursive_call_cannot_cross_a_function_boundary_in_a_tailRec_annotated_function);
+                    }
+                }
+                return visitEachChild(node, checkTailRecNestedFunction(functionNode), nullTransformationContext);
+            }
+        }
+
+        function checkTailRecReturnStatement(functionNode: FunctionDeclaration, parameterSymbols: ReadonlyArray<Symbol>, firstIter = true) {
+            return function (node: Node): VisitResult<Node> {
+                const funcNameSymbol = getSymbolAtLocation(functionNode.name!)
+                if (isCallExpression(node)) {
+                    if(firstIter) {
+                        return node;
+                    }
+                    const symbol = getSymbolAtLocation(node.expression);
+                    if (symbol === funcNameSymbol) {
+                        error(node, Diagnostics.A_recursive_call_must_be_in_a_tail_position_of_a_tailRec_annotated_function);
+                        return node;
+                    }
+                }
+                else {
+                    return visitEachChild(node, checkTailRecReturnStatement(functionNode, parameterSymbols, false), nullTransformationContext)
+                }
+            }
+        }
+
         function checkFunctionDeclaration(node: FunctionDeclaration): void {
             if (produceDiagnostics) {
+                if (isTailRec(node)) {
+                    checkTailRecFunction(node);
+                }
                 checkFunctionOrMethodDeclaration(node);
                 checkGrammarForGenerator(node);
                 checkCollisionsForDeclarationName(node, node.name);

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -274,7 +274,7 @@ namespace ts {
     }));
 
     // TSPLUS EXTENSION START
-    const invertedBinaryOp = {
+    export const invertedBinaryOp = {
         [SyntaxKind.LessThanToken]: "<" as __String,
         [SyntaxKind.GreaterThanToken]: ">" as __String,
         [SyntaxKind.LessThanEqualsToken]: "<=" as __String,

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -7251,5 +7251,17 @@
     "A 'return' statement cannot be used inside a class static block.": {
         "category": "Error",
         "code": 18041
+    },
+    "A recursive call must be in a tail position of a 'tailRec' annotated function.": {
+        "category": "Error",
+        "code": 50000
+    },
+    "A recursive call cannot cross a function boundary in a 'tailRec' annotated function.": {
+        "category": "Error",
+        "code": 50001
+    },
+    "Parameter destructuring is not allowed in a 'tailRec' annotated function.": {
+        "category": "Error",
+        "code": 50002
     }
 }

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -7263,5 +7263,9 @@
     "Parameter destructuring is not allowed in a 'tailRec' annotated function.": {
         "category": "Error",
         "code": 50002
+    },
+    "Invalid declaration annotated as 'tailRec'": {
+        "category": "Error",
+        "code": 50003
     }
 }

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -1967,7 +1967,7 @@ namespace ts {
 
             const emitTransformers = getTransformers(options, customTransformers, emitOnlyDtsFiles);
             const patchedTransformers: EmitTransformers = {
-                scriptTransformers: [transformTsPlus(checker, options, host), ...emitTransformers.scriptTransformers],
+                scriptTransformers: [transformTsPlus(checker, options, host), transformTailRec(checker, options, host), ...emitTransformers.scriptTransformers],
                 declarationTransformers: emitTransformers.declarationTransformers
             }
             const emitResult = emitFiles(

--- a/src/compiler/transformers/tailRec.ts
+++ b/src/compiler/transformers/tailRec.ts
@@ -1,0 +1,230 @@
+/*@internal*/
+namespace ts {
+    export function transformTailRec(checker: TypeChecker, _options: CompilerOptions, _host: CompilerHost) {
+        return function (context: TransformationContext) {
+            return chainBundle(context, transformSourceFile);
+
+            function transformSourceFile (node: SourceFile) {
+                return visitEachChild(node, visitor(node), context);
+            }
+            function visitor(source: SourceFile) {
+                return function (node: Node): VisitResult<Node> {
+                    switch (node.kind) {
+                        case SyntaxKind.VariableDeclaration:
+                            return visitVariableDeclaration(node as VariableDeclaration, context);
+                        case SyntaxKind.FunctionDeclaration:
+                            return visitFunctionDeclaration(node as FunctionDeclaration, context);
+                        default:
+                            return visitEachChild(node, visitor(source), context);
+                    }
+                }
+            }
+            type IdentifierParameter = Omit<ParameterDeclaration, "name"> & { name: Identifier }
+            type FunctionWithBody =
+                | Omit<FunctionDeclaration, "body" | "parameters"> & { body: Block, parameters: NodeArray<IdentifierParameter> }
+                | Omit<ArrowFunction, "body" | "parameters"> & { body: ConciseBody, parameters: NodeArray<IdentifierParameter> }
+            function visitVariableDeclaration(node: VariableDeclaration, context: TransformationContext): VisitResult<Node> {
+                if (node.name && isIdentifier(node.name) && node.initializer && isArrowFunction(node.initializer) && every(node.initializer.parameters, (p) => isIdentifier(p.name))) {
+                    return visitFunction(node.name, node, node.initializer as FunctionWithBody, context);
+                } else {
+                    return node
+                }
+            }
+            function visitFunctionDeclaration(node: FunctionDeclaration, context: TransformationContext): VisitResult<Node> {
+                if (node.name && node.body && every(node.parameters, (p) => isIdentifier(p.name))) {
+                    return visitFunction(node.name, node, node as FunctionWithBody, context);
+                } else {
+                    return node;
+                }
+            }
+            function visitFunction(name: Identifier, declaration: FunctionDeclaration | VariableDeclaration, node: FunctionWithBody, context: TransformationContext) {
+                const funcType = checker.getTypeAtLocation(node)
+                const funcSymbol = funcType.symbol
+
+                let tailRecTag: JSDocTag | undefined = undefined;
+                if (funcSymbol && funcSymbol.declarations) {
+                    for (const declaration of funcSymbol.declarations) {
+                        tailRecTag = getAllJSDocTags(
+                            declaration,
+                            (tag): tag is JSDocTag =>
+                                tag.tagName.escapedText === "tsplus" &&
+                                typeof tag.comment === "string" &&
+                                tag.comment.startsWith("tailRec")
+                        )[0];
+                        if (tailRecTag) {
+                            break;
+                        }
+                    }
+                }
+                if (tailRecTag) {
+                    const originalParamNames = map(node.parameters, (param) => param.name);
+                    const [paramVariableNames, paramVariableDeclarations] = createTempVariables(node, factory);
+                    const [tempVariableNames, tempVariableDeclarations] = createTempVariables(node, factory);
+                    const funcIdentifierType = checker.getTypeAtLocation(name);
+                    try {
+                        const loopBody = visitEachChild(
+                            isBlock(node.body) ? node.body : factory.createBlock([factory.createReturnStatement(node.body)]),
+                            visitFunctionBody(
+                                funcIdentifierType,
+                                originalParamNames,
+                                paramVariableNames,
+                                tempVariableNames,
+                                checker,
+                                factory,
+                                context,
+                            ),
+                            context
+                        );
+                        const functionBody = factory.createBlock(
+                            [
+                                factory.createVariableStatement(
+                                    undefined,
+                                    factory.createVariableDeclarationList(paramVariableDeclarations)
+                                ),
+                                factory.createVariableStatement(
+                                    undefined,
+                                    factory.createVariableDeclarationList(tempVariableDeclarations)
+                                ),
+                                factory.createWhileStatement(
+                                    factory.createNumericLiteral(1),
+                                    loopBody
+                                ),
+                            ],
+                            true
+                        );
+                        if (isArrowFunction(node) && isVariableDeclaration(declaration)) {
+                            return factory.updateVariableDeclaration(
+                                declaration,
+                                declaration.name,
+                                declaration.exclamationToken,
+                                declaration.type,
+                                factory.updateArrowFunction(
+                                    node,
+                                    node.modifiers,
+                                    node.typeParameters,
+                                    node.parameters,
+                                    node.type,
+                                    node.equalsGreaterThanToken,
+                                    functionBody
+                                )
+                            );
+                        } else if (isFunctionDeclaration(node)) {
+                            return factory.updateFunctionDeclaration(
+                                node,
+                                node.decorators,
+                                node.modifiers,
+                                node.asteriskToken,
+                                node.name,
+                                node.typeParameters,
+                                node.parameters,
+                                node.type,
+                                functionBody
+                            );
+                        } else {
+                            return declaration;
+                        }
+                    }
+                    catch (e) {
+                        console.error(e);
+                        throw new Error("Unable to optimize tail recursive function")
+                    }
+                } else {
+                    return declaration
+                }
+            }
+            function createTempVariables(
+                node: FunctionWithBody,
+                factory: NodeFactory
+            ): [Array<Identifier>, Array<VariableDeclaration>] {
+                return reduceLeft(node.parameters, (b, param) => {
+                    const uniqueName = factory.createUniqueName(unescapeLeadingUnderscores(param.name.escapedText))
+                    b[0].push(uniqueName)
+                    b[1].push(factory.createVariableDeclaration(uniqueName, undefined, undefined, param.name))
+                    return b
+                }, [[] as Array<Identifier>, [] as Array<VariableDeclaration>])
+            }
+            function visitExpression(originalParamIdentifiers: ReadonlyArray<Identifier>, tempParamIdentifiers: ReadonlyArray<Identifier>, checker: TypeChecker, factory: NodeFactory, context: TransformationContext) {
+                return function(node: Node): VisitResult<Node> {
+                    if (isIdentifier(node)) {
+                        const symbol = checker.getSymbolAtLocation(node);
+                        const paramIndex = findIndex(originalParamIdentifiers, (param) => checker.getSymbolAtLocation(param) === symbol);
+                        if (paramIndex !== -1) {
+                            return tempParamIdentifiers[paramIndex];
+                        } else {
+                            return node;
+                        }
+                    } else {
+                        return visitEachChild(node, visitExpression(originalParamIdentifiers, tempParamIdentifiers, checker, factory, context), context);
+                    }
+                }
+            }
+            function visitFunctionBody(
+                funcIdentifierType: Type,
+                originalParamNames: ReadonlyArray<Identifier>,
+                paramNames: ReadonlyArray<Identifier>,
+                tempNames: ReadonlyArray<Identifier>,
+                checker: TypeChecker,
+                factory: NodeFactory,
+                context: TransformationContext,
+            ) {
+                return function (node: Node): VisitResult<Node> {
+                    if (isReturnStatement(node) && node.expression) {
+                        if(isCallExpression(node.expression) && isIdentifier(node.expression.expression)) {
+                            const callIdentifierType = checker.getTypeAtLocation(node.expression.expression);
+                            if (callIdentifierType === funcIdentifierType) {
+                                const tempAssignments: Array<ExpressionStatement> = []
+                                const assignments: Array<ExpressionStatement> = []
+                                for (let argIndex = 0, propIndex = 0; argIndex < node.expression.arguments.length; ++argIndex) {
+                                    const arg = node.expression.arguments[argIndex];
+                                    tempAssignments.push(
+                                        factory.createExpressionStatement(
+                                            factory.createAssignment(
+                                                tempNames[propIndex],
+                                                visitEachChild(arg, visitExpression(originalParamNames, paramNames, checker, factory, context), context)
+                                            )
+                                        )
+                                    );
+                                    assignments.push(
+                                        factory.createExpressionStatement(
+                                            factory.createAssignment(
+                                                paramNames[propIndex],
+                                                tempNames[propIndex]
+                                            )
+                                        )
+                                    );
+                                    propIndex += 1;
+                                }
+                                const statements: Array<Statement> = tempAssignments.concat(assignments);
+                                statements.push(factory.createContinueStatement());
+                                return statements
+                            } else {
+                                return node;
+                            }
+                        }
+                        else {
+                            return ts.visitEachChild(
+                                node,
+                                visitExpression(originalParamNames, paramNames, checker, factory, context),
+                                context
+                            );
+                        }
+                    }
+                    else if (isExpression(node)) {
+                        return ts.visitEachChild(
+                            node,
+                            visitExpression(originalParamNames, paramNames, checker, factory, context),
+                            context
+                        );
+                    }
+                    else {
+                        return ts.visitEachChild(
+                            node,
+                            visitFunctionBody(funcIdentifierType, originalParamNames, paramNames, tempNames, checker, factory, context),
+                            context
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/compiler/tsconfig.json
+++ b/src/compiler/tsconfig.json
@@ -60,6 +60,7 @@
         "transformers/es2015.ts",
         "transformers/es5.ts",
         "transformers/tsplus.ts",
+        "transformers/tailRec.ts",
         "transformers/generators.ts",
         "transformers/module/module.ts",
         "transformers/module/system.ts",

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -4523,6 +4523,8 @@ namespace ts {
         isPipeCall(node: CallExpression): boolean
         getCallExtension(node: Node): { patched: Symbol, definition: SourceFile, exportName: string } | undefined
         isTailRec(node: FunctionDeclaration): boolean
+        cloneSymbol(symbol: Symbol): Symbol
+        getTextOfBinaryOp(kind: SyntaxKind): string | undefined
     }
 
     /* @internal */

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -4522,6 +4522,7 @@ namespace ts {
         shouldMakeLazy(signatureParam: Symbol, callArg: Type): boolean
         isPipeCall(node: CallExpression): boolean
         getCallExtension(node: Node): { patched: Symbol, definition: SourceFile, exportName: string } | undefined
+        isTailRec(node: FunctionDeclaration): boolean
     }
 
     /* @internal */

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -4522,7 +4522,7 @@ namespace ts {
         shouldMakeLazy(signatureParam: Symbol, callArg: Type): boolean
         isPipeCall(node: CallExpression): boolean
         getCallExtension(node: Node): { patched: Symbol, definition: SourceFile, exportName: string } | undefined
-        isTailRec(node: FunctionDeclaration): boolean
+        isTailRec(node: Node): boolean
         cloneSymbol(symbol: Symbol): Symbol
         getTextOfBinaryOp(kind: SyntaxKind): string | undefined
     }

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -1679,10 +1679,6 @@ namespace ts {
         }
 
         // TSPLUS EXTENSION BEGIN
-        function isSymbolParameterDeclaration(symbol: Symbol): symbol is Symbol & { valueDeclaration: ParameterDeclaration } {
-            return !!symbol.valueDeclaration && isVariableLike(symbol.valueDeclaration) && isParameterDeclaration(symbol.valueDeclaration);
-        }
-
         function getUntracedDisplayParts(typeChecker: TypeChecker, node: Node, declaration: FunctionDeclaration | VariableDeclaration & { name: Identifier }, resolvedSignature: Signature, /* symbol: TsPlusStaticSymbol | TsPlusFluentSymbol | TsPlusFluentVariableSymbol */): SymbolDisplayPart[] {
             const paramLength = resolvedSignature.parameters.length;
             const lastParam = resolvedSignature.parameters[paramLength - 1];
@@ -1717,7 +1713,7 @@ namespace ts {
                     untracedDeclaration,
                     resolvedSignature.typeParameters,
                     resolvedSignature.thisParameter,
-                    resolvedSignature.parameters.slice(0, resolvedSignature.parameters.length - 1),
+                    filterLazyArgument(typeChecker, resolvedSignature.parameters.slice(0, resolvedSignature.parameters.length - 1)),
                     resolvedSignature.getReturnType(),
                     resolvedSignature.resolvedTypePredicate,
                     resolvedSignature.minArgumentCount - 1,
@@ -1845,8 +1841,7 @@ namespace ts {
                 }
                 if (isToken(node) && isBinaryExpression(node.parent)) {
                     const leftType = typeChecker.getTypeAtLocation(node.parent.left)
-                    // @ts-expect-error
-                    const operator = invertedBinaryOp[node.kind] as string | undefined;
+                    const operator = typeChecker.getTextOfBinaryOp(node.kind);
                     if (operator) {
                         const overload = typeChecker.getOperatorExtension(leftType, operator)
                         if (overload) {


### PR DESCRIPTION
Note: There may still be instances of the `A | LazyArgument<A>` union in help text, but this should get rid of a lot of them. I think we can deal with the rest in a follow-up PR.