### PR TITLE
feat: type-driven fluent overload resolution ("multi-methods")

### DIFF
--- a/effect/src/index.ts
+++ b/effect/src/index.ts
@@ -10,6 +10,8 @@ export const isPositiveEff = (n: number) =>
 
 export const resultEither = isPositive(0).match(() => "nope", () => "yeah");
 
+Effect.succeedNow("A")
+
 export const prog = Effect.do
   .bind("a", () => Effect(0))
   .bind("b", () => Effect(1))

--- a/effect/src/prelude/definition/Maybe.ts
+++ b/effect/src/prelude/definition/Maybe.ts
@@ -34,14 +34,14 @@ export function unifyMaybe<X extends Maybe<any>>(self: X): Maybe<
 /**
  * @tsplus static MaybeOps nothing
  */
-export function nothing(): Maybe<never> {
+export const nothing = (): Maybe<never> => {
     return { _tag: "Nothing" }
 }
 
 /**
  * @tsplus static MaybeOps just
  */
-export function just<A>(value: A): Maybe<A> {
+export const just = <A>(value: A): Maybe<A> => {
     return { _tag: "Just", value }
 }
 

--- a/effect/src/prelude/operations/succeedWith.ts
+++ b/effect/src/prelude/operations/succeedWith.ts
@@ -19,3 +19,12 @@ export function succeedWith<A>(effect: LazyArgument<A>, __tsplusTrace?: string):
 export function effectApply<A>(effect: LazyArgument<A>, __tsplusTrace?: string): Effect<unknown, never, A> {
     return T.succeedWith(effect, __tsplusTrace);
 }
+
+/**
+ * Imports a pure value into an Effect
+ *
+ * @tsplus static ets/EffectOps succeedNow
+ */
+export function succeedNow<A>(value: A, __tsplusTrace?: string): Effect<unknown, never, A> {
+    return T.succeed(value, __tsplusTrace);
+}

--- a/effect/src/type-driven-overloads.ts
+++ b/effect/src/type-driven-overloads.ts
@@ -1,0 +1,4 @@
+import { T } from "./type-driven-overloads/T.js";
+
+T.make("A").op("A")
+T.make(1).op(0);

--- a/effect/src/type-driven-overloads/T.ts
+++ b/effect/src/type-driven-overloads/T.ts
@@ -1,0 +1,20 @@
+/**
+ * @tsplus type T
+ */
+export interface T<A> {
+  readonly value: A
+}
+
+/**
+ * @tsplus type TOps
+ */
+export interface TOps {}
+
+export const T: TOps = {}
+
+/**
+ * @tsplus static TOps make
+ */
+export function make<A>(value: A): T<A> {
+  return { value }
+}

--- a/effect/src/type-driven-overloads/op1.ts
+++ b/effect/src/type-driven-overloads/op1.ts
@@ -1,0 +1,8 @@
+import { T } from './T.js'
+
+/**
+ * @tsplus fluent T op
+ */
+export function op1 <A>(_self: T<A>, x: string): T<string> {
+  return { value: x }
+}

--- a/effect/src/type-driven-overloads/op2.ts
+++ b/effect/src/type-driven-overloads/op2.ts
@@ -1,0 +1,8 @@
+import { T } from './T.js'
+
+/**
+ * @tsplus fluent T op
+ */
+export function op2 <A>(_self: T<A>, x: number): T<number> {
+  return { value: x }
+}

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -351,12 +351,14 @@ namespace ts {
         // TSPLUS EXTENSION START
         const importAsCache = new Map<string, string>();
         const typeSymbolCache = new Map<Symbol, string[]>();
-        const fluentCache = new Map<string, ESMap<string, { patched: Symbol, definition: SourceFile, exportName: string }>>();
+        const fluentCache = new Map<string, ESMap<string, TsPlusFluentExtension>>();
+        const fluentTempCache = new Map<string, ESMap<string, Set<{ signatures: readonly TsPlusSignature[], definition: SourceFile, exportName: string }>>>();
         const getterCache = new Map<string, ESMap<string, { patched: (node: Expression) => Symbol | undefined, definition: SourceFile, exportName: string }>>();
         const operatorCache = new Map<string, ESMap<string, { patched: Symbol, definition: SourceFile, exportName: string }>>();
-        const staticCache = new Map<string, ESMap<string, { patched: Symbol, definition: SourceFile, exportName: string }>>();
+        const staticFunctionCache = new Map<string, ESMap<string, TsPlusStaticFunctionExtension>>()
+        const staticValueCache = new Map<string, ESMap<string, TsPlusStaticValueExtension>>();
         const identityCache = new Map<string, FunctionDeclaration>();
-        const callCache = new Map<Node, { patched: Symbol, definition: SourceFile, exportName: string }>();
+        const callCache = new Map<Node, TsPlusStaticFunctionExtension>();
         const indexCache = new Map<string, { declaration: FunctionDeclaration, definition: SourceFile, exportName: string }>();
         const indexAccessExpressionCache = new Map<Node, { declaration: FunctionDeclaration, definition: SourceFile, exportName: string }>();
         // TSPLUS EXTENSION END
@@ -783,7 +785,8 @@ namespace ts {
             getGetterExtension,
             getFluentExtension,
             getOperatorExtension,
-            getStaticExtension,
+            getStaticFunctionExtension,
+            getStaticValueExtension,
             getCallExtension,
             shouldMakeLazy,
             isPipeCall,
@@ -840,11 +843,17 @@ namespace ts {
             symbols.forEach((target) => {
                 if (typeSymbolCache.has(target)) {
                     typeSymbolCache.get(target)!.forEach((typeSymbol) => {
-                        const _static = staticCache.get(typeSymbol);
-                        if (_static) {
-                            _static.forEach((v, k) => {
-                                copy.set(k, v.patched);
+                        const _staticFunctions = staticFunctionCache.get(typeSymbol);
+                        if (_staticFunctions) {
+                            _staticFunctions.forEach((v, k) => {
+                                copy.set(k, v.patched)
                             });
+                        }
+                        const _staticValues = staticValueCache.get(typeSymbol);
+                        if(_staticValues) {
+                            _staticValues.forEach((v, k) => {
+                                copy.set(k, v.patched);
+                            })
                         }
                         const _fluent = fluentCache.get(typeSymbol);
                         if (_fluent) {
@@ -905,14 +914,14 @@ namespace ts {
                 }
             }
         }
-        function getStaticExtension(targetType: Type, name: string) {
+        function getStaticFunctionExtension(targetType: Type, name: string) {
             const symbols = collectRelevantSymbols(targetType)
             for (const target of symbols) {
                 if (typeSymbolCache.has(target)) {
                     const x = typeSymbolCache.get(target)!.flatMap(
                         (tag) => {
-                            if (staticCache.has(tag)) {
-                                const cache = staticCache.get(tag)
+                            if (staticFunctionCache.has(tag)) {
+                                const cache = staticFunctionCache.get(tag)
                                 if (cache?.has(name)) {
                                     return [cache.get(name)!]
                                 }
@@ -920,6 +929,22 @@ namespace ts {
                             return []
                         }
                     )
+                    return x.length > 0 ? x[x.length - 1] : undefined;
+                }
+            }
+        }
+        function getStaticValueExtension(targetType: Type, name: string) {
+            const symbols = collectRelevantSymbols(targetType);
+            for (const target of symbols) {
+                if (typeSymbolCache.has(target)) {
+                    const x = flatMap(typeSymbolCache.get(target)!, (tag) => {
+                        if (staticValueCache.has(tag)) {
+                            const cache = staticValueCache.get(tag)
+                            if (cache?.has(name)) {
+                                return [cache.get(name)!]
+                            }
+                        }
+                    });
                     return x.length > 0 ? x[x.length - 1] : undefined;
                 }
             }
@@ -25480,7 +25505,7 @@ namespace ts {
             // for the symbol. Also, don't mark any property access expression LHS - checkPropertyAccessExpression will handle that
             if (!(node.parent && isPropertyAccessExpression(node.parent) && node.parent.expression === node)) {
                 // We should also not mark as used identifiers that will be replaced
-                if (!(node.parent && isCallExpression(node.parent) && node.parent.expression === node && getSignaturesOfType(type, SignatureKind.Call).length === 0 && getStaticExtension(type, "__call") != null)) {
+                if (!(node.parent && isCallExpression(node.parent) && node.parent.expression === node && getSignaturesOfType(type, SignatureKind.Call).length === 0 && getStaticFunctionExtension(type, "__call") != null)) {
                     markAliasReferenced(getResolvedSymbol(node), node);
                 }
             }
@@ -28794,9 +28819,16 @@ namespace ts {
                         return type;
                     }
                 }
-                const staticExt = getStaticExtension(leftType, right.escapedText.toString())
-                if (staticExt) {
-                    return getTypeOfSymbol(staticExt.patched)
+                const staticFuncExt = getStaticFunctionExtension(leftType, right.escapedText.toString());
+                if (staticFuncExt) {
+                    return getTypeOfSymbol(staticFuncExt.patched);
+                }
+                const staticValExt = getStaticValueExtension(leftType, right.escapedText.toString());
+                if (staticValExt) {
+                    const type = getTypeOfSymbol(staticValExt.patched);
+                    // @ts-expect-error
+                    type.tsPlusSymbol = staticValExt.patched;
+                    return type;
                 }
             }
         }
@@ -30911,7 +30943,7 @@ namespace ts {
 
             // TSPLUS EXTENSION START
             if (callSignatures.length === 0) {
-                const callExtension = getStaticExtension(apparentType, "__call");
+                const callExtension = getStaticFunctionExtension(apparentType, "__call");
                 
                 if (callExtension) {
                     callSignatures = Array.from(getSignaturesOfType(getTypeOfSymbol(callExtension.patched), SignatureKind.Call));
@@ -43066,8 +43098,15 @@ namespace ts {
                 (tag): tag is TsPlusJSDocOperatorTag => tag.tagName.escapedText === "tsplus" && typeof tag.comment === "string" && tag.comment.startsWith("getter")
             );
         }
-        function thisifyTsPlusSignature(call: Signature) {
-            const signature = cloneSignature(call);
+        function createTsPlusSignature(call: Signature, exportName: string, file: SourceFile): TsPlusSignature {
+            const signature = cloneSignature(call) as TsPlusSignature
+            signature.tsPlusTag = "TsPlusSignature";
+            signature.tsPlusFile = file;
+            signature.tsPlusExportName = exportName;
+            return signature
+        }
+        function thisifyTsPlusSignature(call: Signature, exportName: string, file: SourceFile) {
+            const signature = createTsPlusSignature(call, exportName, file);
             const target = signature.parameters[0];
             signature.thisParameter = createSymbolWithType(createSymbol(target.flags, "this" as __String), getTypeOfSymbol(target));
             const typePredicate = getTypePredicateOfSignature(call);
@@ -43084,19 +43123,10 @@ namespace ts {
             signature.instantiations = call.instantiations;
             return signature;
         }
-        function createTsPlusFluentFunctionSymbol(name: string, dataFirst: FunctionDeclaration, signatures: Signature[]): TsPlusFluentSymbol {
+        function createTsPlusFluentSymbol(name: string, signatures: TsPlusSignature[]): TsPlusFluentSymbol {
             const symbol = createSymbol(SymbolFlags.Function, name as __String) as TsPlusFluentSymbol;
             symbol.tsPlusTag = TsPlusSymbolTag.Fluent;
-            symbol.tsPlusDeclaration = dataFirst;
             symbol.tsPlusResolvedSignatures = signatures;
-            symbol.tsPlusName = name;
-            return symbol;
-        }
-        function createTsPlusFluentVariableSymbol(name: string, declaration: VariableDeclaration & { name: Identifier }, signatures: Signature[]): TsPlusFluentVariableSymbol {
-            const symbol = createSymbol(SymbolFlags.Function, name as __String) as TsPlusFluentVariableSymbol;
-            symbol.tsPlusTag = TsPlusSymbolTag.FluentVariable;
-            symbol.tsPlusDeclaration = declaration;
-            symbol.tsPlusResolvedSignatures = signatures as SignatureWithParameters[];
             symbol.tsPlusName = name;
             return symbol;
         }
@@ -43109,16 +43139,20 @@ namespace ts {
             symbol.tsPlusName = name;
             return symbol;
         }
-        function createTsPlusStaticFunctionSymbol(name: string, dataFirst: FunctionDeclaration, signatures: Signature[]): TsPlusStaticSymbol {
-            const symbol = createSymbol(SymbolFlags.Function, name as __String) as TsPlusStaticSymbol;
-            symbol.tsPlusTag = TsPlusSymbolTag.Static;
-            symbol.tsPlusDeclaration = dataFirst;
+        function createTsPlusStaticFunctionSymbol(name: string, declaration: FunctionDeclaration | VariableDeclarationWithFunction, signatures: Signature[]): TsPlusStaticFunctionSymbol {
+            const symbol = createSymbol(SymbolFlags.Function, name as __String) as TsPlusStaticFunctionSymbol;
+            symbol.tsPlusTag = TsPlusSymbolTag.StaticFunction;
+            symbol.tsPlusDeclaration = declaration;
             symbol.tsPlusResolvedSignatures = signatures;
             symbol.tsPlusName = name;
             return symbol;
         }
-        function createTsPlusStaticVariableSymbol(name: string, declaration: VariableDeclaration, originalSymbol: Symbol): Symbol {
-            const symbol = cloneSymbol(originalSymbol);
+        function createTsPlusStaticValueSymbol(name: string, declaration: VariableDeclaration, originalSymbol: Symbol): Symbol {
+            const symbol = cloneSymbol(originalSymbol) as TsPlusStaticValueSymbol;
+            symbol.tsPlusTag = TsPlusSymbolTag.StaticValue;
+            symbol.tsPlusResolvedSignatures = [];
+            symbol.tsPlusName = name;
+            symbol.tsPlusDeclaration = declaration as VariableDeclaration & { name: Identifier };
             symbol.escapedName = name as __String;
             const patchedDeclaration = factory.updateVariableDeclaration(
                 declaration,
@@ -43144,22 +43178,16 @@ namespace ts {
             symbol.tsPlusName = name;
             return symbol;
         }
-        function getTsPlusFluentSymbolForFunctionDeclaration(name: string, dataFirst: FunctionDeclaration) {
+        function getTsPlusFluentSignaturesForFunctionDeclaration(file: SourceFile, exportName: string, dataFirst: FunctionDeclaration) {
             const type = getTypeOfNode(dataFirst);
             const signatures = getSignaturesOfType(type, SignatureKind.Call);
-            const methods = signatures.map(thisifyTsPlusSignature);
-            const symbol = createTsPlusFluentFunctionSymbol(name, dataFirst, methods);
-            const final = createAnonymousType(symbol, emptySymbols, methods, [], []);
-            return createSymbolWithType(symbol, final);
+            return signatures.map((signature) => thisifyTsPlusSignature(signature, exportName, file));
         }
-        function getTsPlusFluentSymbolForVariableDeclaration(name: string, declaration: VariableDeclaration & { name: Identifier }) {
+        function getTsPlusFluentSignaturesForVariableDeclaration(file: SourceFile, exportName: string, declaration: VariableDeclaration & { name: Identifier }) {
             const type = getTypeOfNode(declaration);
             const signatures = getSignaturesOfType(type, SignatureKind.Call);
             if(signatures.every((sigSymbol) => sigSymbol.parameters.every((paramSymbol) => paramSymbol.valueDeclaration && isVariableLike(paramSymbol.valueDeclaration) && isParameterDeclaration(paramSymbol.valueDeclaration)))) {
-                const methods = signatures.map(thisifyTsPlusSignature);
-                const symbol = createTsPlusFluentVariableSymbol(name, declaration, methods);
-                const final = createAnonymousType(symbol, emptySymbols, methods, [], []);
-                return createSymbolWithType(symbol, final);
+                return signatures.map((signature) => thisifyTsPlusSignature(signature, exportName, file));
             }
         }
         function getTsPlusGetterSymbolForFunctionDeclaration(_name: string, _dataFirst: FunctionDeclaration) {
@@ -43188,9 +43216,9 @@ namespace ts {
                 return createTsPlusGetterVariableSymbol(name, declaration, res, getTypeOfNode(selfNode));
             };
         }
-        function getTsPlusStaticSymbolForFunctionDeclaration(name: string, dataFirst: FunctionDeclaration) {
+        function getTsPlusStaticSymbolForFunctionDeclaration(file: SourceFile, exportName: string, name: string, dataFirst: FunctionDeclaration | VariableDeclarationWithFunction) {
             const signatures = getSignaturesOfType(getTypeOfNode(dataFirst), SignatureKind.Call);
-            const methods = signatures.map(cloneSignature);
+            const methods = map(signatures, (s) => createTsPlusSignature(s, exportName, file));
             const symbol = createTsPlusStaticFunctionSymbol(name, dataFirst, methods);
             const final = createAnonymousType(symbol, emptySymbols, methods, [], []);
             return createSymbolWithType(symbol, final);
@@ -43236,19 +43264,33 @@ namespace ts {
             const staticTags = collectTsPlusStaticTags(statement);
             for (const staticTag of staticTags) {
                 const [, target, name] = staticTag.comment.split(" ");
-                if (!staticCache.has(target)) {
-                    staticCache.set(target, new Map());
-                }
-                const map = staticCache.get(target)!;
                 const declaration = statement.declarationList.declarations[0];
-                const symbol = getSymbolAtLocation(declaration.name);
-                if (symbol) {
-                    const patched = createTsPlusStaticVariableSymbol(name, declaration, symbol);
-                    map.set(name, {
-                        patched,
-                        definition: file,
-                        exportName: symbol.escapedName.toString()
-                    })
+                if (declaration.initializer && (isArrowFunction(declaration.initializer) || isFunctionExpression(declaration.initializer))) {
+                    if (!staticFunctionCache.has(target)) {
+                        staticFunctionCache.set(target, new Map());
+                    }
+                    const map = staticFunctionCache.get(target)!
+                    const symbol = getSymbolAtLocation(declaration.name)
+                    if (symbol) {
+                        map.set(name, {
+                            patched: getTsPlusStaticSymbolForFunctionDeclaration(file, symbol.escapedName.toString(), name, declaration as VariableDeclarationWithFunction),
+                            definition: file,
+                            exportName: symbol.escapedName.toString()
+                        })
+                    }
+                } else {
+                    if (!staticValueCache.has(target)) {
+                        staticValueCache.set(target, new Map());
+                    }
+                    const map = staticValueCache.get(target)!;
+                    const symbol = getSymbolAtLocation(declaration.name);
+                    if (symbol) {
+                        map.set(name, {
+                            patched: createTsPlusStaticValueSymbol(name, declaration, symbol),
+                            definition: file,
+                            exportName: symbol.escapedName.toString()
+                        })
+                    }
                 }
             }
         }
@@ -43259,17 +43301,22 @@ namespace ts {
                     const fluentTags = collectTsPlusFluentTags(declaration);
                     for (const fluentTag of fluentTags) {
                         const [, target, name] = fluentTag.comment.split(" ");
-                        if (!fluentCache.has(target)) {
-                            fluentCache.set(target, new Map());
+                        if (!fluentTempCache.has(target)) {
+                            fluentTempCache.set(target, new Map());
                         }
-                        const patched = getTsPlusFluentSymbolForVariableDeclaration(
-                            name,
+                        const signatures = getTsPlusFluentSignaturesForVariableDeclaration(
+                            file,
+                            declaration.name.escapedText.toString(),
                             (declaration as VariableDeclaration & { name: Identifier })
                         )
-                        if(patched) {
-                            const map = fluentCache.get(target)!;
-                            map.set(name, {
-                                patched,
+                        if(signatures) {
+                            const map = fluentTempCache.get(target)!;
+                            if (!map.has(name)) {
+                                map.set(name, new Set());
+                            }
+                            const set = map.get(name)!
+                            set.add({
+                                signatures,
                                 exportName: declaration.name.escapedText.toString(),
                                 definition: file
                             })
@@ -43329,12 +43376,16 @@ namespace ts {
                 const fluentTags = collectTsPlusFluentTags(declaration);
                 for (const fluentTag of fluentTags) {
                     const [, target, name] = fluentTag.comment.split(" ");
-                    if (!fluentCache.has(target)) {
-                        fluentCache.set(target, new Map());
+                    if (!fluentTempCache.has(target)) {
+                        fluentTempCache.set(target, new Map());
                     }
-                    const map = fluentCache.get(target)!;
-                    map.set(name, {
-                        patched: getTsPlusFluentSymbolForFunctionDeclaration(name, declaration),
+                    const map = fluentTempCache.get(target)!;
+                    if (!map.has(name)) {
+                        map.set(name, new Set());
+                    }
+                    const set = map.get(name)!
+                    set.add({
+                        signatures: getTsPlusFluentSignaturesForFunctionDeclaration(file, declaration.name.escapedText.toString(), declaration),
                         exportName: declaration.name.escapedText.toString(),
                         definition: file
                     });
@@ -43363,12 +43414,12 @@ namespace ts {
                 const staticTags = collectTsPlusStaticTags(declaration);
                 for (const staticTag of staticTags) {
                     const [, target, name] = staticTag.comment.split(" ");
-                    if (!staticCache.has(target)) {
-                        staticCache.set(target, new Map());
+                    if (!staticFunctionCache.has(target)) {
+                        staticFunctionCache.set(target, new Map());
                     }
-                    const map = staticCache.get(target)!;
+                    const map = staticFunctionCache.get(target)!;
                     map.set(name, {
-                        patched: getTsPlusStaticSymbolForFunctionDeclaration(name, declaration),
+                        patched: getTsPlusStaticSymbolForFunctionDeclaration(file, declaration.name.escapedText.toString(), name, declaration),
                         exportName: declaration.name.escapedText.toString(),
                         definition: file
                     });
@@ -43424,9 +43475,11 @@ namespace ts {
         }
         function initTsPlusTypeChecker() {
             fluentCache.clear();
+            fluentTempCache.clear();
             operatorCache.clear();
             typeSymbolCache.clear();
-            staticCache.clear();
+            staticFunctionCache.clear();
+            staticValueCache.clear();
             identityCache.clear();
             getterCache.clear();
             callCache.clear();
@@ -43435,6 +43488,22 @@ namespace ts {
             for (const file of host.getSourceFiles()) {
                 collectTsPlusSymbols(file, file.statements);
             }
+
+            fluentTempCache.forEach((map, typeName) => {
+                if (!fluentCache.has(typeName)) {
+                    fluentCache.set(typeName, new Map());
+                }
+                const cache = fluentCache.get(typeName)!;
+                map.forEach((members, funcName) => {
+                    const signatures: TsPlusSignature[] = []
+                    members.forEach((cached) => {
+                        signatures.push(...cached.signatures);
+                    })
+                    const symbol = createTsPlusFluentSymbol(funcName, signatures);
+                    const type = createAnonymousType(symbol, emptySymbols, signatures, [], []);
+                    cache.set(funcName, { patched: createSymbolWithType(symbol, type), signatures })
+                })
+            })
         }
         // TSPLUS EXTENSION END
 
@@ -45403,6 +45472,9 @@ namespace ts {
     export function isTsPlusSymbol(symbol: Symbol): symbol is TsPlusSymbol {
         return 'tsPlusTag' in symbol;
     }
+    export function isTsPlusSignature(signature: Signature): signature is TsPlusSignature {
+        return 'tsPlusTag' in signature;
+    }
     export function getNameForType(type: Type | undefined): string | undefined {
         if(!type) {
             return;
@@ -45429,7 +45501,6 @@ namespace ts {
     }
     export function getThisTypeNameForTsPlusSymbol(symbol: TsPlusSymbol): string {
         switch(symbol.tsPlusTag) {
-            case TsPlusSymbolTag.FluentVariable:
             case TsPlusSymbolTag.Fluent: {
                 if(symbol.tsPlusResolvedSignatures[0] && symbol.tsPlusResolvedSignatures[0].thisParameter) {
                     return getNameForType((symbol.tsPlusResolvedSignatures[0].thisParameter as TransientSymbol).type) || anon;
@@ -45440,7 +45511,7 @@ namespace ts {
             case TsPlusSymbolTag.Getter: {
                 return getNameForType(symbol.tsPlusSelfType) || anon;
             }
-            case TsPlusSymbolTag.Static: {
+            case TsPlusSymbolTag.StaticFunction: {
                 // Statics do not have a `this` type
                 break;
             }
@@ -45459,6 +45530,38 @@ namespace ts {
 
     export function isTsPlusType(type: Type): type is TsPlusType {
         return "tsPlusSymbol" in type;
+    }
+
+    type TsPlusSymbolWithDeclaration = Omit<TsPlusType, "tsPlusSymbol"> & {
+        tsPlusSymbol: TsPlusGetterSymbol | TsPlusGetterVariableSymbol | TsPlusStaticValueSymbol
+    }
+
+    export function isTsPlusTypeWithDeclaration(type: Type): type is TsPlusSymbolWithDeclaration {
+        return isTsPlusType(type) && (
+            type.tsPlusSymbol.tsPlusTag === TsPlusSymbolTag.Getter ||
+            type.tsPlusSymbol.tsPlusTag === TsPlusSymbolTag.GetterVariable ||
+            type.tsPlusSymbol.tsPlusTag === TsPlusSymbolTag.StaticValue
+        )
+    }
+
+    export function getDeclarationForTsPlus(checker: TypeChecker, node: Node, symbol: TsPlusSymbol): Declaration | undefined {
+        switch (symbol.tsPlusTag) {
+            case TsPlusSymbolTag.StaticFunction:
+            case TsPlusSymbolTag.Fluent: {
+                if (isCallLikeExpression(node)) {
+                    const signature = checker.getResolvedSignature(node)
+                    if (signature && signature.declaration) {
+                        return signature.declaration
+                    }
+                }
+                break;
+            }
+            case TsPlusSymbolTag.StaticValue:
+            case TsPlusSymbolTag.Getter:
+            case TsPlusSymbolTag.GetterVariable: {
+                return symbol.tsPlusDeclaration
+            }
+        }
     }
 
     // TSPLUS EXTENSION END

--- a/src/services/goToDefinition.ts
+++ b/src/services/goToDefinition.ts
@@ -45,9 +45,17 @@ namespace ts.GoToDefinition {
         if(isPropertyAccessExpression(parent)) {
             const nodeType = typeChecker.getTypeAtLocation(node);
             if(nodeType.symbol && isTsPlusSymbol(nodeType.symbol)) {
-                symbol = nodeType.symbol.tsPlusDeclaration.symbol;
+                if (parent.parent && isCallLikeExpression(parent.parent)) {
+                    const declaration = getDeclarationForTsPlus(typeChecker, parent.parent, nodeType.symbol)
+                    if (declaration) {
+                        symbol = declaration.symbol
+                    }
+                }
+                if (!symbol && nodeType.symbol.tsPlusTag !== TsPlusSymbolTag.Fluent) {
+                    symbol = nodeType.symbol.tsPlusDeclaration.symbol;
+                }
             }
-            else if (isTsPlusType(nodeType)) {
+            else if (isTsPlusTypeWithDeclaration(nodeType)) {
                 symbol = nodeType.tsPlusSymbol.tsPlusDeclaration.symbol;
             }
             else {
@@ -56,11 +64,11 @@ namespace ts.GoToDefinition {
 
                 if(extensions) {
                     const name = parent.name.escapedText.toString();
-                    const staticSymbol = typeChecker.getStaticExtension(type, name);
-                    if(staticSymbol) {
-                        // If execution gets here, it means we have a const static extension,
+                    const staticValueSymbol = typeChecker.getStaticValueExtension(type, name);
+                    if(staticValueSymbol) {
+                        // If execution gets here, it means we have a static variable extension,
                         // which needs to be treated a little differently
-                        const declaration = staticSymbol.patched.valueDeclaration;
+                        const declaration = staticValueSymbol.patched.valueDeclaration;
                         if(declaration && declaration.original) {
                             symbol = declaration.original.symbol;
                         }

--- a/src/services/signatureHelp.ts
+++ b/src/services/signatureHelp.ts
@@ -101,7 +101,7 @@ namespace ts.SignatureHelp {
                             untracedDeclaration,
                             resolvedSignature.typeParameters,
                             resolvedSignature.thisParameter,
-                            resolvedSignature.parameters,
+                            resolvedSignature.parameters.slice(0, declaration.parameters.length - 1),
                             resolvedSignature.getReturnType(),
                             resolvedSignature.resolvedTypePredicate,
                             resolvedSignature.minArgumentCount,
@@ -109,19 +109,6 @@ namespace ts.SignatureHelp {
                         );
                         resolvedSignature = untracedSignature;
                         candidates = [untracedSignature];
-                    } else if (some(resolvedSignature.parameters, isLazyParameter)) {
-                        const signature = checker.createSignature(
-                            declaration,
-                            resolvedSignature.typeParameters,
-                            resolvedSignature.thisParameter,
-                            resolvedSignature.parameters,
-                            resolvedSignature.getReturnType(),
-                            resolvedSignature.resolvedTypePredicate,
-                            resolvedSignature.minArgumentCount,
-                            resolvedSignature.flags
-                        );
-                        resolvedSignature = signature;
-                        candidates = [resolvedSignature];
                     }
                 }
                 // TSPLUS EXTENSION END


### PR DESCRIPTION
Closes #18 

In addition to adding the type-driven overloads feature, this PR also refactors and clarifies how extensions are collected, as well as fixes a few minor bugs DX bugs:

- Resolved type parameters didn't show on `__tsplusTrace` functions
- Signature help showing `__tsplusTrace`