### PR TITLE
fix: don't require ambient modules to be exported

### DIFF
--- a/effect/src/index.ts
+++ b/effect/src/index.ts
@@ -31,14 +31,18 @@ x.assertJust();
 
 const z = x.value;
 
+declare global {
+  /**
+   * @tsplus type Array
+   */
+  export interface Array<T> {}
+}
 
+/**
+ * @tsplus fluent Array map0
+ */
+export function afunc <A>(self: Array<A>, f: (a: A) => A): Array<A> {
+  return self.map(f);
+}
 
-
-
-
-
-
-
-
-
-Effect.fail(0)
+[].map0((a) => a)

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -43252,12 +43252,12 @@ namespace ts {
         }
         function collectTsPlusSymbols(file: SourceFile, statements: NodeArray<Statement>): void {
             for (const statement of statements) {
+                if (isModuleDeclaration(statement) && statement.body && isModuleBlock(statement.body)) {
+                    collectTsPlusSymbols(file, statement.body.statements)
+                }
                 if(statement.modifiers && findIndex(statement.modifiers, t => t.kind === SyntaxKind.ExportKeyword) !== -1) {
                     if (isInterfaceDeclaration(statement) || isTypeAliasDeclaration(statement)) {
                         tryCacheTsPlusType(statement)
-                    }
-                    if (isModuleDeclaration(statement) && statement.body && isModuleBlock(statement.body)) {
-                        collectTsPlusSymbols(file, statement.body.statements)
                     }
                     if (isVariableStatement(statement) && statement.declarationList.declarations.length === 1) {
                         tryCacheTsPlusStaticVariable(file, statement);


### PR DESCRIPTION
Since ambient modules cannot have an `export` modifier, this condition caused `@tsplus type` annotations not to be collected.