### PR TITLE
Fixes

### DIFF
--- a/effect/src/index.ts
+++ b/effect/src/index.ts
@@ -41,8 +41,15 @@ declare global {
 /**
  * @tsplus fluent Array map0
  */
-export function afunc <A>(self: Array<A>, f: (a: A) => A): Array<A> {
+export function arrayFunc <A>(self: Array<A>, f: (a: A) => A): Array<A> {
   return self.map(f);
 }
 
-[].map0((a) => a)
+/**
+ * @tsplus getter Array getter
+ */
+export function arrayGetter <A>(self: Array<A>): Array<A> {
+  return self;
+}
+
+const a = [1, 2, 3].map0((a) => a).getter.map0((a) => a).getter

--- a/effect/src/index.ts
+++ b/effect/src/index.ts
@@ -31,14 +31,18 @@ x.assertJust();
 
 const z = x.value;
 
+declare global {
+  /**
+   * @tsplus type Array
+   */
+  export interface Array<T> {}
+}
 
+/**
+ * @tsplus fluent Array map0
+ */
+export function afunc <A>(self: Array<A>, f: (a: A) => A): Array<A> {
+  return self.map(f);
+}
 
-
-
-
-
-
-
-
-
-Effect.fail(0)
+[].map0((a) => a)

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -43252,12 +43252,12 @@ namespace ts {
         }
         function collectTsPlusSymbols(file: SourceFile, statements: NodeArray<Statement>): void {
             for (const statement of statements) {
+                if (isModuleDeclaration(statement) && statement.body && isModuleBlock(statement.body)) {
+                    collectTsPlusSymbols(file, statement.body.statements)
+                }
                 if(statement.modifiers && findIndex(statement.modifiers, t => t.kind === SyntaxKind.ExportKeyword) !== -1) {
                     if (isInterfaceDeclaration(statement) || isTypeAliasDeclaration(statement)) {
                         tryCacheTsPlusType(statement)
-                    }
-                    if (isModuleDeclaration(statement) && statement.body && isModuleBlock(statement.body)) {
-                        collectTsPlusSymbols(file, statement.body.statements)
                     }
                     if (isVariableStatement(statement) && statement.declarationList.declarations.length === 1) {
                         tryCacheTsPlusStaticVariable(file, statement);

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -36607,13 +36607,19 @@ namespace ts {
                         nullTransformationContext
                     );
                 }
-                else {
-                    return visitEachChild(
-                        node,
-                        checkTailRecFunctionVisitor(functionNode, parameterSymbols),
-                        nullTransformationContext
-                    );
+                else if (isCallExpression(node)) {
+                    const funcNameSymbol = getSymbolAtLocation(functionNode.name!);
+                    const symbol = getSymbolAtLocation(node.expression);
+                    if (symbol === funcNameSymbol) {
+                        error(node, Diagnostics.A_recursive_call_must_be_in_a_tail_position_of_a_tailRec_annotated_function);
+                        return node;
+                    }
                 }
+                return visitEachChild(
+                    node,
+                    checkTailRecFunctionVisitor(functionNode, parameterSymbols),
+                    nullTransformationContext
+                );
             };
         }
         function getSymbolsOfBindingName(node: BindingName): readonly Symbol[] {

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -4523,7 +4523,7 @@ namespace ts {
 
         getGlobalImport(file: SourceFile): string
         getLocalImport(from: SourceFile, file: SourceFile): string
-        getExtensions(targetType: Type): ESMap<string, Symbol>
+        getExtensions(targetType: Type, selfNode: Expression): ESMap<string, Symbol>
         getFluentExtension(target: Type, name: string): { patched: Symbol, definition: SourceFile, exportName: string } | undefined
         getGetterExtension(target: Type, name: string): { definition: SourceFile, exportName: string } | undefined
         getStaticExtension(target: Type, name: string): { patched: Symbol, definition: SourceFile, exportName: string } | undefined

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -3313,6 +3313,7 @@ namespace ts {
         tsPlusTag: TsPlusSymbolTag.Fluent
         tsPlusDeclaration: FunctionDeclaration;
         tsPlusResolvedSignatures: Signature[];
+        tsPlusName: string;
     }
 
     export type SignatureWithParameters = Omit<Signature, "parameters"> & { parameters: ReadonlyArray<Symbol & { valueDeclaration: ParameterDeclaration }> }
@@ -3322,24 +3323,28 @@ namespace ts {
         tsPlusDeclaration: VariableDeclaration & { name: Identifier };
         tsPlusParameters: ReadonlyArray<ParameterDeclaration>;
         tsPlusResolvedSignatures: SignatureWithParameters[];
+        tsPlusName: string;
     }
 
     export interface TsPlusStaticSymbol extends TransientSymbol {
         tsPlusTag: TsPlusSymbolTag.Static;
         tsPlusDeclaration: FunctionDeclaration;
         tsPlusResolvedSignatures: Signature[];
+        tsPlusName: string;
     }
 
     export interface TsPlusGetterSymbol extends TransientSymbol {
         tsPlusTag: TsPlusSymbolTag.Getter;
         tsPlusSelfType: Type;
         tsPlusDeclaration: FunctionDeclaration;
+        tsPlusName: string;
     }
 
     export interface TsPlusGetterVariableSymbol extends TransientSymbol {
         tsPlusTag: TsPlusSymbolTag.GetterVariable;
         tsPlusDeclaration: VariableDeclaration & { name: Identifier };
         tsPlusSelfType: Type;
+        tsPlusName: string;
     }
 
     export type TsPlusSymbol =
@@ -3348,6 +3353,10 @@ namespace ts {
         | TsPlusGetterSymbol
         | TsPlusFluentVariableSymbol
         | TsPlusGetterVariableSymbol;
+
+    export interface TsPlusType extends Type {
+        tsPlusSymbol: TsPlusSymbol;
+    }
 
     export interface JSDocLink extends Node {
         readonly kind: SyntaxKind.JSDocLink;

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -2172,11 +2172,13 @@ namespace ts.Completions {
                 }
             }
 
-            const extensions = typeChecker.getExtensions(type);
-            if (extensions) {
-                extensions.forEach((extension) => {
-                    addPropertySymbol(extension, /* insertAwait */ false, /* insertQuestionDot */ false);
-                });
+            if (isExpressionNode(node)) {
+                const extensions = typeChecker.getExtensions(type, node as Expression);
+                if (extensions) {
+                    extensions.forEach((extension) => {
+                        addPropertySymbol(extension, /* insertAwait */ false, /* insertQuestionDot */ false);
+                    });
+                }
             }
 
             if (insertAwait && preferences.includeCompletionsWithInsertText) {

--- a/src/services/goToDefinition.ts
+++ b/src/services/goToDefinition.ts
@@ -46,7 +46,11 @@ namespace ts.GoToDefinition {
             const nodeType = typeChecker.getTypeAtLocation(node);
             if(nodeType.symbol && isTsPlusSymbol(nodeType.symbol)) {
                 symbol = nodeType.symbol.tsPlusDeclaration.symbol;
-            } else {
+            }
+            else if (isTsPlusType(nodeType)) {
+                symbol = nodeType.tsPlusSymbol.tsPlusDeclaration.symbol;
+            }
+            else {
                 const type = typeChecker.getTypeAtLocation(parent.expression);
                 const extensions = typeChecker.getExtensions(type);
 

--- a/src/services/goToDefinition.ts
+++ b/src/services/goToDefinition.ts
@@ -52,7 +52,7 @@ namespace ts.GoToDefinition {
             }
             else {
                 const type = typeChecker.getTypeAtLocation(parent.expression);
-                const extensions = typeChecker.getExtensions(type);
+                const extensions = typeChecker.getExtensions(type, parent.expression);
 
                 if(extensions) {
                     const name = parent.name.escapedText.toString();

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -1679,7 +1679,7 @@ namespace ts {
         }
 
         // TSPLUS EXTENSION BEGIN
-        function getUntracedDisplayParts(typeChecker: TypeChecker, node: Node, declaration: FunctionDeclaration | VariableDeclaration & { name: Identifier }, resolvedSignature: Signature, /* symbol: TsPlusStaticSymbol | TsPlusFluentSymbol | TsPlusFluentVariableSymbol */): SymbolDisplayPart[] {
+        function getUntracedDisplayParts(typeChecker: TypeChecker, node: Node, declaration: FunctionDeclaration | VariableDeclaration & { name: Identifier }, resolvedSignature: Signature): SymbolDisplayPart[] {
             const paramLength = resolvedSignature.parameters.length;
             const lastParam = resolvedSignature.parameters[paramLength - 1];
             if (resolvedSignature.parameters.every(isSymbolParameterDeclaration) && lastParam && lastParam.name === "__tsplusTrace") {
@@ -1695,7 +1695,8 @@ namespace ts {
                         declaration.type,
                         undefined
                     );
-                } else {
+                }
+                else {
                     untracedDeclaration = factory.createFunctionDeclaration(
                         declaration.decorators,
                         declaration.modifiers,
@@ -1723,7 +1724,8 @@ namespace ts {
                     cancellationToken,
                     typeChecker => signatureToDisplayParts(typeChecker, untracedSignature, getContainerNode(node))
                 );
-            } else {
+            }
+            else {
                 return typeChecker.runWithCancellationToken(
                     cancellationToken,
                     typeChecker => signatureToDisplayParts(typeChecker, resolvedSignature, getContainerNode(node))
@@ -1747,11 +1749,11 @@ namespace ts {
             const symbol = getSymbolAtLocationForQuickInfo(nodeForQuickInfo, typeChecker);
 
             // TSPLUS EXTENSION BEGIN
-            const call = typeChecker.getCallExtension(nodeForQuickInfo)
+            const call = typeChecker.getCallExtension(nodeForQuickInfo);
             if(call) {
-                const symbol = typeChecker.getTypeOfSymbol(call.patched).symbol
+                const symbol = typeChecker.getTypeOfSymbol(call.patched).symbol;
                 if(isTsPlusSymbol(symbol) && symbol.tsPlusTag === TsPlusSymbolTag.Static) {
-                    let displayParts: SymbolDisplayPart[] = []
+                    let displayParts: SymbolDisplayPart[] = [];
                     displayParts.push(textPart("("));
                     displayParts.push(textPart("call"));
                     displayParts.push(textPart(")"));
@@ -1773,80 +1775,88 @@ namespace ts {
             if (!symbol || typeChecker.isUnknownSymbol(symbol)) {
                 const type = shouldGetType(sourceFile, nodeForQuickInfo, position) ? typeChecker.getTypeAtLocation(nodeForQuickInfo) : undefined;
                 // TSPLUS EXTENSION BEGIN
-                if(type && type.symbol && isTsPlusSymbol(type.symbol)) {
-                    let displayParts: SymbolDisplayPart[] = []
-                    switch(type.symbol.tsPlusTag) {
-                        case TsPlusSymbolTag.FluentVariable:
-                        case TsPlusSymbolTag.Fluent: {
-                            displayParts.push(textPart("("));
-                            displayParts.push(textPart("fluent"));
-                            displayParts.push(textPart(")"));
-                            displayParts.push(spacePart());
-                            displayParts.push(displayPart(getThisTypeNameForTsPlusSymbol(type.symbol), SymbolDisplayPartKind.className));
-                            displayParts.push(punctuationPart(SyntaxKind.DotToken));
-                            displayParts.push(displayPart(type.symbol.escapedName as string, SymbolDisplayPartKind.methodName));
-                            break;
-                        }
-                        case TsPlusSymbolTag.Static: {
-                            displayParts.push(textPart("("));
-                            displayParts.push(textPart("static"));
-                            displayParts.push(textPart(")"));
-                            displayParts.push(spacePart());
-                            displayParts.push(displayPart(type.symbol.escapedName as string, SymbolDisplayPartKind.methodName));
-                            break;
-                        }
-                        case TsPlusSymbolTag.GetterVariable:
-                        case TsPlusSymbolTag.Getter: {
-                            displayParts.push(textPart("("));
-                            displayParts.push(textPart("getter"));
-                            displayParts.push(textPart(")"));
-                            displayParts.push(spacePart());
-                            displayParts.push(displayPart(getThisTypeNameForTsPlusSymbol(type.symbol), SymbolDisplayPartKind.className));
-                            displayParts.push(punctuationPart(SyntaxKind.DotToken));
-                            displayParts.push(displayPart(type.symbol.name, SymbolDisplayPartKind.fieldName));
-                            displayParts.push(punctuationPart(SyntaxKind.ColonToken));
-                            displayParts.push(spacePart());
-                            break;
-                        }
+                if (type) {
+                    let tsPlusSymbol: TsPlusSymbol | undefined;
+                    if (type.symbol && isTsPlusSymbol(type.symbol)) {
+                        tsPlusSymbol = type.symbol;
                     }
-                    switch(type.symbol.tsPlusTag) {
-                        case TsPlusSymbolTag.FluentVariable:
-                        case TsPlusSymbolTag.Fluent:
-                        case TsPlusSymbolTag.Static: {
-                            const symbol = type.symbol;
-                            const declaration = symbol.tsPlusDeclaration;
-                            displayParts = displayParts.concat(getUntracedDisplayParts(typeChecker, nodeForQuickInfo, declaration, symbol.tsPlusResolvedSignatures[0]));
-                            return {
-                                kind: ScriptElementKind.memberFunctionElement,
-                                kindModifiers: ScriptElementKindModifier.staticModifier,
-                                textSpan: createTextSpanFromNode(nodeForQuickInfo, sourceFile),
-                                displayParts,
-                                documentation: getDocumentationComment([declaration], typeChecker),
-                                tags: getJsDocTagsOfDeclarations([declaration], typeChecker)
-                            };
+                    else if (type && isTsPlusType(type)) {
+                        tsPlusSymbol = type.tsPlusSymbol;
+                    }
+                    if(tsPlusSymbol) {
+                        let displayParts: SymbolDisplayPart[] = [];
+                        switch(tsPlusSymbol.tsPlusTag) {
+                            case TsPlusSymbolTag.FluentVariable:
+                            case TsPlusSymbolTag.Fluent: {
+                                displayParts.push(textPart("("));
+                                displayParts.push(textPart("fluent"));
+                                displayParts.push(textPart(")"));
+                                displayParts.push(spacePart());
+                                displayParts.push(displayPart(getThisTypeNameForTsPlusSymbol(tsPlusSymbol), SymbolDisplayPartKind.className));
+                                displayParts.push(punctuationPart(SyntaxKind.DotToken));
+                                displayParts.push(displayPart(tsPlusSymbol.tsPlusName, SymbolDisplayPartKind.methodName));
+                                break;
+                            }
+                            case TsPlusSymbolTag.Static: {
+                                displayParts.push(textPart("("));
+                                displayParts.push(textPart("static"));
+                                displayParts.push(textPart(")"));
+                                displayParts.push(spacePart());
+                                displayParts.push(displayPart(tsPlusSymbol.tsPlusName, SymbolDisplayPartKind.methodName));
+                                break;
+                            }
+                            case TsPlusSymbolTag.GetterVariable:
+                            case TsPlusSymbolTag.Getter: {
+                                displayParts.push(textPart("("));
+                                displayParts.push(textPart("getter"));
+                                displayParts.push(textPart(")"));
+                                displayParts.push(spacePart());
+                                displayParts.push(displayPart(getThisTypeNameForTsPlusSymbol(tsPlusSymbol), SymbolDisplayPartKind.className));
+                                displayParts.push(punctuationPart(SyntaxKind.DotToken));
+                                displayParts.push(displayPart(tsPlusSymbol.tsPlusName, SymbolDisplayPartKind.fieldName));
+                                displayParts.push(punctuationPart(SyntaxKind.ColonToken));
+                                displayParts.push(spacePart());
+                                break;
+                            }
                         }
-                        case TsPlusSymbolTag.GetterVariable:
-                        case TsPlusSymbolTag.Getter: {
-                            displayParts = displayParts.concat(typeChecker.runWithCancellationToken(cancellationToken, typeChecker => typeToDisplayParts(typeChecker, type, getContainerNode(nodeForQuickInfo))));
-                            return {
-                                kind: ScriptElementKind.memberGetAccessorElement,
-                                kindModifiers: ScriptElementKindModifier.none,
-                                textSpan: createTextSpanFromNode(nodeForQuickInfo, sourceFile),
-                                displayParts,
-                                documentation: getDocumentationComment([type.symbol.tsPlusDeclaration], typeChecker),
-                                tags: getJsDocTagsOfDeclarations([type.symbol.tsPlusDeclaration], typeChecker)
+                        switch(tsPlusSymbol.tsPlusTag) {
+                            case TsPlusSymbolTag.FluentVariable:
+                            case TsPlusSymbolTag.Fluent:
+                            case TsPlusSymbolTag.Static: {
+                                const declaration = tsPlusSymbol.tsPlusDeclaration;
+                                displayParts = displayParts.concat(getUntracedDisplayParts(typeChecker, nodeForQuickInfo, declaration, tsPlusSymbol.tsPlusResolvedSignatures[0]));
+                                return {
+                                    kind: ScriptElementKind.memberFunctionElement,
+                                    kindModifiers: ScriptElementKindModifier.staticModifier,
+                                    textSpan: createTextSpanFromNode(nodeForQuickInfo, sourceFile),
+                                    displayParts,
+                                    documentation: getDocumentationComment([declaration], typeChecker),
+                                    tags: getJsDocTagsOfDeclarations([declaration], typeChecker)
+                                };
+                            }
+                            case TsPlusSymbolTag.GetterVariable:
+                            case TsPlusSymbolTag.Getter: {
+                                displayParts = displayParts.concat(typeChecker.runWithCancellationToken(cancellationToken, typeChecker => typeToDisplayParts(typeChecker, type, getContainerNode(nodeForQuickInfo))));
+                                return {
+                                    kind: ScriptElementKind.memberGetAccessorElement,
+                                    kindModifiers: ScriptElementKindModifier.none,
+                                    textSpan: createTextSpanFromNode(nodeForQuickInfo, sourceFile),
+                                    displayParts,
+                                    documentation: getDocumentationComment([tsPlusSymbol.tsPlusDeclaration], typeChecker),
+                                    tags: getJsDocTagsOfDeclarations([tsPlusSymbol.tsPlusDeclaration], typeChecker)
+                                };
                             }
                         }
                     }
                 }
                 if (isToken(node) && isBinaryExpression(node.parent)) {
-                    const leftType = typeChecker.getTypeAtLocation(node.parent.left)
+                    const leftType = typeChecker.getTypeAtLocation(node.parent.left);
                     const operator = typeChecker.getTextOfBinaryOp(node.kind);
                     if (operator) {
-                        const overload = typeChecker.getOperatorExtension(leftType, operator)
+                        const overload = typeChecker.getOperatorExtension(leftType, operator);
                         if (overload) {
-                            const declaration = find(overload.patched.declarations || [], isFunctionDeclaration)
-                            const declarationSignature = declaration ? typeChecker.getSignatureFromDeclaration(declaration) : undefined
+                            const declaration = find(overload.patched.declarations || [], isFunctionDeclaration);
+                            const declarationSignature = declaration ? typeChecker.getSignatureFromDeclaration(declaration) : undefined;
                             if (declaration && declarationSignature) {
                                 let displayParts: SymbolDisplayPart[] = [];
                                 displayParts.push(textPart("("));
@@ -1860,7 +1870,7 @@ namespace ts {
                                         cancellationToken,
                                         (typeChecker) => getUntracedDisplayParts(typeChecker, node, declaration, declarationSignature)
                                     )
-                                )
+                                );
                                 return {
                                     kind: ScriptElementKind.functionElement,
                                     kindModifiers: ScriptElementKindModifier.none,
@@ -1868,7 +1878,7 @@ namespace ts {
                                     displayParts,
                                     documentation: getDocumentationComment([declaration], typeChecker),
                                     tags: getJsDocTagsOfDeclarations([declaration], typeChecker)
-                                }
+                                };
                             }
                         }
                     }
@@ -1881,7 +1891,7 @@ namespace ts {
                         const name = node.parent.name.escapedText as string;
                         const staticSymbol = typeChecker.getStaticExtension(parentType, name);
                         if(type && staticSymbol) {
-                            const declaration = staticSymbol.patched.valueDeclaration
+                            const declaration = staticSymbol.patched.valueDeclaration;
                             if (declaration) {
                                 let displayParts: SymbolDisplayPart[] = [];
                                 displayParts.push(textPart("("));
@@ -1889,7 +1899,7 @@ namespace ts {
                                 displayParts.push(textPart(")"));
                                 displayParts.push(spacePart());
                                 displayParts.push(displayPart(name, SymbolDisplayPartKind.fieldName));
-                                displayParts.push(punctuationPart(SyntaxKind.ColonToken))
+                                displayParts.push(punctuationPart(SyntaxKind.ColonToken));
                                 displayParts.push(spacePart());
                                 displayParts = displayParts.concat(
                                     typeChecker.runWithCancellationToken(
@@ -1904,7 +1914,7 @@ namespace ts {
                                     displayParts,
                                     documentation: getDocumentationComment([declaration], typeChecker),
                                     tags: getJsDocTagsOfDeclarations([declaration], typeChecker)
-                                }
+                                };
                             }
                         }
                     }

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -1884,12 +1884,12 @@ namespace ts {
                     }
                 }
                 if(isPropertyAccessExpression(node.parent)) {
-                    const parentType = typeChecker.getTypeAtLocation(node.parent.expression);
-                    const extensions = typeChecker.getExtensions(parentType);
+                    const targetType = typeChecker.getTypeAtLocation(node.parent.expression);
+                    const extensions = typeChecker.getExtensions(targetType, node.parent.expression);
                     if(extensions) {
                         const type = typeChecker.getTypeAtLocation(node);
                         const name = node.parent.name.escapedText as string;
-                        const staticSymbol = typeChecker.getStaticExtension(parentType, name);
+                        const staticSymbol = typeChecker.getStaticExtension(targetType, name);
                         if(type && staticSymbol) {
                             const declaration = staticSymbol.patched.valueDeclaration;
                             if (declaration) {


### PR DESCRIPTION
Includes some fixes in one PR for easy merging:

- #16 
- #19 

Also fixes an issue I found with getters. I was overwriting the "real" symbol in `checkPropertyAccessForExtension`, which made TypeScript typechecking fail later in some circumstances (found by trying to put getter extensions on `Array`).