### PR TITLE
Pipeable

### DIFF
--- a/effect/src/prelude/operations/flatMap.ts
+++ b/effect/src/prelude/operations/flatMap.ts
@@ -11,3 +11,5 @@ import { Effect } from "../definition/Effect.js";
 export function chain_<R, E, A, R1, E1, A1>(self: Effect<R, E, A>, f: (a: A) => Effect<R1, E1, A1>, __tsplusTrace?: string): Effect<R & R1, E | E1, A1> {
     return T.chain_(self, f, __tsplusTrace);
 }
+
+export const chain = Pipeable(chain_)

--- a/effect/src/prelude/operations/flatMap.ts
+++ b/effect/src/prelude/operations/flatMap.ts
@@ -8,8 +8,10 @@ import { Effect } from "../definition/Effect.js";
  *
  * @tsplus fluent ets/Effect flatMap
  */
-export function chain_<R, E, A, R1, E1, A1>(self: Effect<R, E, A>, f: (a: A) => Effect<R1, E1, A1>, __tsplusTrace?: string): Effect<R & R1, E | E1, A1> {
-    return T.chain_(self, f, __tsplusTrace);
+export function chain_<R, E, A, R1, E1, A1>(
+  self: Effect<R, E, A>,
+  f: (a: A) => Effect<R1, E1, A1>,
+  __tsplusTrace?: string
+): Effect<R & R1, E | E1, A1> {
+  return T.chain_(self, f, __tsplusTrace);
 }
-
-export const chain = Pipeable(chain_)

--- a/effect/src/prelude/operations/pipeable.ts
+++ b/effect/src/prelude/operations/pipeable.ts
@@ -1,0 +1,6 @@
+import { bind_ } from "./bind";
+import { chain_ } from "./flatMap";
+
+export const chain = Pipeable(chain_);
+
+export const bind = Pipeable(bind_);

--- a/effect/src/utils/Pipeable.ts
+++ b/effect/src/utils/Pipeable.ts
@@ -1,0 +1,7 @@
+declare type PipeableShift<A extends any[]> = A extends [infer X, ...infer Rest] ? Rest : never
+declare type PipeableFirst<A extends any[]> = A extends [infer X, ...infer Rest] ? X : never
+
+/**
+ * @tsplus macro pipeable
+ */
+declare function Pipeable<F extends (self: any, ...rest: any) => any>(f: F): (...rest: PipeableShift<Parameters<F>>) => (self: PipeableFirst<Parameters<F>>) => ReturnType<F>

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -797,7 +797,8 @@ namespace ts {
             getInstantiatedTsPlusSignature,
             getIndexAccessExpressionCache: () => indexAccessExpressionCache,
             resolveStaticExtension,
-            getUnresolvedStaticExtension
+            getUnresolvedStaticExtension,
+            isTsPlusMacroCall
             // TSPLUS EXTENSION END
         };
 

--- a/src/compiler/transformers/tsplus.ts
+++ b/src/compiler/transformers/tsplus.ts
@@ -208,30 +208,36 @@ namespace ts {
                     )
                     if (signatureDeclaration && signatureDeclaration.type && isFunctionTypeNode(signatureDeclaration.type)) {
                         const returnType = signatureDeclaration.type
-                        return factory.createFunctionDeclaration(
-                            undefined,
+                        return factory.createVariableStatement(
                             [factory.createModifier(SyntaxKind.ExportKeyword)],
-                            undefined,
-                            node.name,
-                            signatureDeclaration.typeParameters,
-                            signatureDeclaration.parameters,
-                            signatureDeclaration.type,
-                            factory.createBlock([
-                                factory.createReturnStatement(factory.createArrowFunction(
+                            factory.createVariableDeclarationList([
+                                factory.createVariableDeclaration(
+                                    node.name,
                                     undefined,
-                                    returnType.typeParameters,
-                                    returnType.parameters,
-                                    returnType.type,
                                     undefined,
-                                    factory.createCallExpression(
-                                        node.initializer.arguments[0],
+                                    factory.createArrowFunction(
                                         undefined,
-                                        [
-                                            ...map(signatureDeclaration.type.parameters, (pdecl) => pdecl.name as Identifier),
-                                            ...map(signatureDeclaration.parameters, (pdecl) => pdecl.name as Identifier)
-                                        ]
+                                        signatureDeclaration.typeParameters,
+                                        signatureDeclaration.parameters,
+                                        signatureDeclaration.type,
+                                        undefined,
+                                        factory.createArrowFunction(
+                                            undefined,
+                                            returnType.typeParameters,
+                                            returnType.parameters,
+                                            returnType.type,
+                                            undefined,
+                                            factory.createCallExpression(
+                                                node.initializer.arguments[0],
+                                                undefined,
+                                                [
+                                                    ...map(signatureDeclaration.type.parameters, (pdecl) => pdecl.name as Identifier),
+                                                    ...map(signatureDeclaration.parameters, (pdecl) => pdecl.name as Identifier)
+                                                ]
+                                            )
+                                        )
                                     )
-                                ))
+                                )
                             ])
                         )
                     }

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -3325,7 +3325,7 @@ namespace ts {
         tsPlusResolvedSignatures: TsPlusSignature[];
     }
 
-    export type VariableDeclarationWithFunction = VariableDeclaration & { name: Identifier, initializer: ArrowFunction | FunctionExpression };
+    export type VariableDeclarationWithFunction = Omit<VariableDeclaration, "name" | "initializer"> & { name: Identifier, initializer: ArrowFunction | FunctionExpression };
 
     export interface TsPlusUnresolvedStaticSymbol extends TransientSymbol {
         tsPlusTag: TsPlusSymbolTag.UnresolvedStatic

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -4585,6 +4585,7 @@ namespace ts {
         getIndexAccessExpressionCache(): ESMap<Node, { declaration: FunctionDeclaration, definition: SourceFile, exportName: string }>
         resolveStaticExtension(unresolved: TsPlusUnresolvedStaticExtension): Type | undefined
         getUnresolvedStaticExtension(targetType: Type, name: string): TsPlusUnresolvedStaticExtension | undefined
+        isTsPlusMacroCall<K extends string>(node: Node, macro: K): node is TsPlusMacroCallExpression<K>
     }
 
     /* @internal */

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -3307,6 +3307,9 @@ namespace ts {
         readonly comment: `macro ${string}`
     }
 
+
+    export type TsPlusMacroCallExpression<K extends string> = CallExpression & { __tsplus_brand: K };
+
     export const enum TsPlusSymbolTag {
         Fluent = "TsPlusFluentSymbol",
         StaticFunction = "TsPlusStaticFunctionSymbol",


### PR DESCRIPTION
This PR adds support for `Pipeable`, a macro that converts a function with a signature such as
```ts
function map_<A, B>(self: T<A>, f: (a: A) => B): T<B>
```
into
```ts
const map = Pipeable(map_)
// becomes
const map = <A, B>(f: (a: A) => B) => (self: T<A>): T<B> => map_(self, f)
```