### PR TITLE
fix: resolve static extensions when `getExtensions` is called

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -851,6 +851,7 @@ namespace ts {
                             _unresolvedStatics.forEach((extension) => {
                                 resolveStaticExtension(extension)
                             })
+                            staticUnresolvedCache.delete(typeSymbol)
                         }
                         const _staticFunctions = staticFunctionCache.get(typeSymbol);
                         if (_staticFunctions) {
@@ -43532,6 +43533,7 @@ namespace ts {
             typeSymbolCache.clear();
             staticFunctionCache.clear();
             staticValueCache.clear();
+            staticUnresolvedCache.clear();
             identityCache.clear();
             getterCache.clear();
             callCache.clear();

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -846,6 +846,12 @@ namespace ts {
             symbols.forEach((target) => {
                 if (typeSymbolCache.has(target)) {
                     typeSymbolCache.get(target)!.forEach((typeSymbol) => {
+                        const _unresolvedStatics = staticUnresolvedCache.get(typeSymbol);
+                        if (_unresolvedStatics) {
+                            _unresolvedStatics.forEach((extension) => {
+                                resolveStaticExtension(extension)
+                            })
+                        }
                         const _staticFunctions = staticFunctionCache.get(typeSymbol);
                         if (_staticFunctions) {
                             _staticFunctions.forEach((v, k) => {


### PR DESCRIPTION
Since static variable extensions are now lazily resolved, the unresolved statics must be resolved when getting all of the extensions for a type.

Also, clears the unresolved cache on `initTsPlusTypeChecker`