### PR TITLE
chore: improve pipeable transformer

### DIFF
--- a/effect/src/prelude/operations/pipeable.ts
+++ b/effect/src/prelude/operations/pipeable.ts
@@ -1,6 +1,0 @@
-import { bind_ } from "./bind";
-import { chain_ } from "./flatMap";
-
-export const chain = Pipeable(chain_);
-
-export const bind = Pipeable(bind_);

--- a/effect/src/prelude/pipeable/pipeable.ts
+++ b/effect/src/prelude/pipeable/pipeable.ts
@@ -1,0 +1,6 @@
+import { bind_ } from "../operations/bind";
+import { chain_ } from "../operations/flatMap";
+
+export const chain = Pipeable(chain_);
+
+export const bind = Pipeable(bind_);


### PR DESCRIPTION
This PR improved the transformer to emit `Pipeable`, with #44 the emitted code looked like:

```
export var chain = (f, __tsplusTrace) => (self) => chain_(self, f, __tsplusTrace);
```

That is because the whole statement node was rebuilt instead of preserving the original statement and patching the initializer, additionally this PR removes the reverse-engineering of signatureToDeclaration and just uses the value declaration of the symbol correspondent to the argument of `Pipeable`, it doesn't carry through type information given that the transformer only runs in the js emit context and the `.d.ts` is already properly generated by TS