### PR TITLE
feat: support extensions for base constraints

### DIFF
--- a/effect/src/index.ts
+++ b/effect/src/index.ts
@@ -70,6 +70,10 @@ const a = [1, 2, 3].map0((a) => a).getter.map0((a) => a).getter.head
 
 const x2 = Effect(0)
 
+function baseConstraint<A extends Array<unknown>>(...xs: A): unknown[] {
+  return xs.map0((a) => a)
+}
+
 function id2<A>(a: A): A { return a }
 
 const xxx2 = id2("aaa")

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -844,7 +844,7 @@ namespace ts {
             return returnArray
         }
         function getExtensions(selfNode: Expression) {
-            const targetType: Type = getTypeOfNode(selfNode);
+            const targetType: Type = getBaseConstraintOrType(getTypeOfNode(selfNode));
             const symbols = collectRelevantSymbols(targetType);
             const copy: ESMap<string, Symbol> = new Map();
             symbols.forEach((target) => {
@@ -891,7 +891,7 @@ namespace ts {
             return copy;
         }
         function getFluentExtension(targetType: Type, name: string) {
-            const symbols = collectRelevantSymbols(targetType)
+            const symbols = collectRelevantSymbols(getBaseConstraintOrType(targetType))
             for (const target of symbols) {
                 if (typeSymbolCache.has(target)) {
                     const x = typeSymbolCache.get(target)!.flatMap(
@@ -910,7 +910,7 @@ namespace ts {
             }
         }
         function getGetterExtension(targetType: Type, name: string) {
-            const symbols = collectRelevantSymbols(targetType)
+            const symbols = collectRelevantSymbols(getBaseConstraintOrType(targetType))
             for (const target of symbols) {
                 if (typeSymbolCache.has(target)) {
                     const x = typeSymbolCache.get(target)!.flatMap(
@@ -929,7 +929,7 @@ namespace ts {
             }
         }
         function getStaticFunctionExtension(targetType: Type, name: string) {
-            const symbols = collectRelevantSymbols(targetType)
+            const symbols = collectRelevantSymbols(getBaseConstraintOrType(targetType))
             for (const target of symbols) {
                 if (typeSymbolCache.has(target)) {
                     const x = typeSymbolCache.get(target)!.flatMap(
@@ -948,7 +948,7 @@ namespace ts {
             }
         }
         function getStaticValueExtension(targetType: Type, name: string) {
-            const symbols = collectRelevantSymbols(targetType);
+            const symbols = collectRelevantSymbols(getBaseConstraintOrType(targetType))
             for (const target of symbols) {
                 if (typeSymbolCache.has(target)) {
                     const x = flatMap(typeSymbolCache.get(target)!, (tag) => {
@@ -964,7 +964,7 @@ namespace ts {
             }
         }
         function getUnresolvedStaticExtension(targetType: Type, name: string) {
-            const symbols = collectRelevantSymbols(targetType)
+            const symbols = collectRelevantSymbols(getBaseConstraintOrType(targetType))
             for (const target of symbols) {
                 if (typeSymbolCache.has(target)) {
                     const x = typeSymbolCache.get(target)!.flatMap(
@@ -983,7 +983,7 @@ namespace ts {
             }
         }
         function getOperatorExtension(targetType: Type, name: string) {
-            const symbols = collectRelevantSymbols(targetType)
+            const symbols = collectRelevantSymbols(getBaseConstraintOrType(targetType))
             for (const target of symbols) {
                 if (typeSymbolCache.has(target)) {
                     const x = typeSymbolCache.get(target)!.flatMap(

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -2173,6 +2173,7 @@ namespace ts.Completions {
                 }
             }
 
+            // TSPLUS EXTENSION START
             if (isExpression(node)) {
                 const extensions = typeChecker.getExtensions(node);
                 if (extensions) {
@@ -2181,6 +2182,7 @@ namespace ts.Completions {
                     });
                 }
             }
+            // TSPLUS EXTENSION END
 
             if (insertAwait && preferences.includeCompletionsWithInsertText) {
                 const promiseType = typeChecker.getPromisedTypeOfPromise(type);


### PR DESCRIPTION
This PR adds support for extensions when working with types that extend a base constraint. For example something like this would not work before, but now it does:

```ts
declare global {
  /**
   * @tsplus type Array
   */
  export interface Array<T> {}
}

/**
 * @tsplus fluent Array tsplusMap
 */
export function map_<A, B>(self: Array<A>, f: (a: A) => B): Array<B> {
  ...
}

export function fn<A extends Array<unknown>>(...xs: A): Array<unknown> {
  return xs.tsplusMap(...) // <-- before: Property 'tsplusMap' does not exist on type 'A'
}
```

This was accomplished by using the checker function `getBaseConstraintOrType` when getting the types of nodes for extensions.