### PR TITLE
fix: avoid transforming `super` call as `__call`

### DIFF
--- a/effect/src/class.ts
+++ b/effect/src/class.ts
@@ -1,8 +1,16 @@
 /**
  * @tsplus type IO
+ * @tsplus companion IOOps
  */
 export class IO<A> {
     constructor(readonly io: () => A) {}
+}
+
+/**
+ * @tsplus static IOOps __call
+ */
+export function applyIO<A>(f: () => A): IO<A> {
+    return new IO(f);
 }
 
 /**
@@ -13,3 +21,9 @@ export function map<A, B>(self: IO<A>, f: (a: A) => B) {
 }
 
 new IO(() => 0).map((n) => n + 1)
+
+export class ExtendedIO<A> extends IO<A> {
+    constructor(io: () => A) {
+        super(io)
+    }
+}

--- a/src/compiler/transformers/tsplus.ts
+++ b/src/compiler/transformers/tsplus.ts
@@ -239,6 +239,10 @@ namespace ts {
                     return optimisePipe(visitNodes(node.arguments, visitor), context.factory)
                 }
                 const expressionType = checker.getTypeAtLocation(node.expression)
+                // Avoid transforming super call as __call extension
+                if (isSuperCall(node)) {
+                    return visitCallExpression(source, traceInScope, node, visitor, context);
+                }
                 if (checker.getSignaturesOfType(expressionType, SignatureKind.Call).length === 0) {
                     if (checker.isClassCompanionReference(node.expression)) {
                         const customCall = checker.getStaticFunctionCompanionExtension(expressionType, "__call")


### PR DESCRIPTION
This bug was produced with the following steps:
- a class was annotated with a `companion` extension
- a `__call` extension was assigned to the companion
- another class extended the original class
- the subclass's constructor called `super`
- the `super` call was transformed into the `__call` extenion