### PR TITLE
feat(macro): add identity and remove macros

### DIFF
--- a/effect/src/macros.ts
+++ b/effect/src/macros.ts
@@ -1,0 +1,17 @@
+/**
+ * @tsplus macro identity
+ */
+function identity<A>(a: A): A {
+  return a
+}
+
+/**
+ * @tsplus macro remove
+ */
+function concrete(u: unknown): asserts u is any {
+  //
+}
+
+identity(0);
+
+concrete(0);

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -7343,5 +7343,25 @@
     "Annotation of a companion extension must have the form '@tsplus companion [typename]'.": {
         "category": "Error",
         "code": 50013
+    },
+    "Annotation of a macro must have the form '@tsplus macro [name]'.": {
+        "category": "Error",
+        "code": 50014
+    },
+    "The argument of an 'identity' macro must not be a spread element.": {
+        "category": "Error",
+        "code": 50015
+    },
+    "Function annotated with 'identity' macro must have one argument.": {
+        "category": "Error",
+        "code": 50016
+    },
+    "Declaration annotated with 'identity' macro must be a function.": {
+        "category": "Error",
+        "code": 50017
+    },
+    "Declaration annotated with 'remove' macro must be a function.": {
+        "category": "Error",
+        "code": 50018
     }
 }

--- a/src/compiler/transformers/tsplus.ts
+++ b/src/compiler/transformers/tsplus.ts
@@ -234,9 +234,24 @@ namespace ts {
                         args[0]!
                     )
             }
+            function optimizeIdentity(
+                node: CallExpression,
+            ): Expression {
+                if (node.arguments.length === 1 && !isSpreadElement(node.arguments[0])) {
+                    return node.arguments[0];
+                } else {
+                    return node;
+                }
+            }
             function visitCallExpressionOrFluentCallExpression(source: SourceFile, traceInScope: Identifier | undefined, node: CallExpression, visitor: Visitor, context: TransformationContext): VisitResult<Node> {
                 if (checker.isPipeCall(node)) {
                     return optimisePipe(visitNodes(node.arguments, visitor), context.factory)
+                }
+                if (checker.isTsPlusMacroCall(node, "identity")) {
+                    return optimizeIdentity(visitEachChild(node, visitor, context));
+                }
+                if (checker.isTsPlusMacroCall(node, "remove")) {
+                    return factory.createVoidZero()
                 }
                 const expressionType = checker.getTypeAtLocation(node.expression)
                 // Avoid transforming super call as __call extension


### PR DESCRIPTION
The `identity` macro is transformed to replace the function call with the first and only argument to the function.

The `remove` macro is transformed to replace the function call with a `void 0` statement.