### PR TITLE
Lazy fluent caching (and other various bugs)

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -1234,10 +1234,10 @@ namespace ts {
             if (!isCallExpression(node)) {
                 return false;
             }
-            const typeOfExpression = getTypeOfNode(node.expression);
-            if (typeOfExpression.symbol && typeOfExpression.symbol.valueDeclaration) {
+            const symbol = getSymbolAtLocation(node.expression);
+            if (symbol && symbol.valueDeclaration) {
                 return getAllJSDocTags(
-                    typeOfExpression.symbol.valueDeclaration,
+                    symbol.valueDeclaration,
                     (_): _ is JSDocTag => _.tagName.escapedText === "tsplus" && _.comment === `macro ${macro}`
                 ).length > 0;
             }

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -807,7 +807,6 @@ namespace ts {
             isClassCompanionReference,
             collectTsPlusFluentTags,
             getFluentExtensionForPipeableSymbol,
-            resolveCall
             // TSPLUS EXTENSION END
         };
 

--- a/src/compiler/transformers/tsplus.ts
+++ b/src/compiler/transformers/tsplus.ts
@@ -272,7 +272,7 @@ namespace ts {
                     const identifierType = checker.getTypeAtLocation(original.expression);
                     const identifierSymbol = identifierType.symbol;
                     if (identifierSymbol && isTsPlusSymbol(identifierSymbol)) {
-                        if (identifierSymbol.tsPlusTag === TsPlusSymbolTag.Pipeable) {
+                        if (identifierSymbol.tsPlusTag === TsPlusSymbolTag.PipeableIdentifier) {
                             const fluentExtension = checker.getFluentExtensionForPipeableSymbol(identifierSymbol);
                             if (fluentExtension) {
                                 const signature = find(fluentExtension.types, ({ type }) => checker.isTypeAssignableTo(identifierSymbol.tsPlusDataFirstType, type))?.signatures[0];
@@ -290,7 +290,7 @@ namespace ts {
                     const identifierType = checker.getTypeAtLocation(original.expression.name);
                     const identifierSymbol = identifierType.symbol;
                     if (identifierSymbol && isTsPlusSymbol(identifierSymbol)) {
-                        if (identifierSymbol.tsPlusTag === TsPlusSymbolTag.Pipeable) {
+                        if (identifierSymbol.tsPlusTag === TsPlusSymbolTag.PipeableIdentifier) {
                             const fluentExtension = checker.getFluentExtensionForPipeableSymbol(identifierSymbol);
                             if (fluentExtension) {
                                 const signature = find(fluentExtension.types, ({ type }) => checker.isTypeAssignableTo(identifierSymbol.tsPlusDataFirstType, type))?.signatures[0];
@@ -306,7 +306,7 @@ namespace ts {
                             const declType = checker.getTypeAtLocation(identifierSymbol.tsPlusDeclaration.name!);
                             const declSym = declType.symbol;
                             if (declSym && isTsPlusSymbol(declSym)) {
-                                if (declSym.tsPlusTag === TsPlusSymbolTag.Pipeable) {
+                                if (declSym.tsPlusTag === TsPlusSymbolTag.PipeableIdentifier) {
                                     const fluentExtension = checker.getFluentExtensionForPipeableSymbol(declSym);
                                     if (fluentExtension) {
                                         const signature = find(fluentExtension.types, ({ type }) => checker.isTypeAssignableTo(declSym.tsPlusDataFirstType, type))?.signatures[0];

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -4640,7 +4640,6 @@ namespace ts {
         isClassCompanionReference(node: Expression): boolean
         collectTsPlusFluentTags(statement: Declaration): readonly TsPlusJSDocExtensionTag[]
         getFluentExtensionForPipeableSymbol(symbol: TsPlusPipeableIdentifierSymbol): TsPlusFluentExtension | undefined
-        resolveCall(node: CallLikeExpression, signatures: readonly Signature[], candidatesOutArray: Signature[] | undefined, checkMode: CheckMode, callChainFlags: SignatureFlags, fallbackError?: DiagnosticMessage): Signature
     }
 
     /* @internal */

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -3319,12 +3319,18 @@ namespace ts {
         Getter = "TsPlusGetterSymbol",
         GetterVariable = "TsPlusGetterVariableSymbol",
         PipeableMacro = "TsPlusPipeableMacroSymbol",
-        Pipeable = "TsPlusPipeableSymbol"
+        PipeableIdentifier = "TsPlusPipeableSymbol",
+        PipeableDeclaration = "TsPlusPipeableDeclarationSymbol"
     }
 
-    export interface TsPlusPipeableSymbol extends TransientSymbol {
-        tsPlusTag: TsPlusSymbolTag.Pipeable;
-        tsPlusDeclaration: FunctionDeclaration | VariableDeclarationWithFunction;
+    export interface TsPlusPipeableDeclarationSymbol extends TransientSymbol {
+        tsPlusTag: TsPlusSymbolTag.PipeableDeclaration
+        tsPlusDeclaration: FunctionDeclaration | VariableDeclarationWithFunction | VariableDeclarationWithFunctionType;
+    }
+
+    export interface TsPlusPipeableIdentifierSymbol extends TransientSymbol {
+        tsPlusTag: TsPlusSymbolTag.PipeableIdentifier;
+        tsPlusDeclaration: FunctionDeclaration | VariableDeclarationWithFunction | VariableDeclarationWithFunctionType;
         tsPlusDataFirstType: Type;
         tsPlusTypeName: string;
         tsPlusName: string;
@@ -3389,7 +3395,8 @@ namespace ts {
         | TsPlusGetterSymbol
         | TsPlusGetterVariableSymbol
         | TsPlusPipeableMacroSymbol
-        | TsPlusPipeableSymbol;
+        | TsPlusPipeableIdentifierSymbol
+        | TsPlusPipeableDeclarationSymbol;
 
     export interface TsPlusFluentExtension {
         patched: Symbol;
@@ -4632,7 +4639,7 @@ namespace ts {
         isTsPlusMacroCall<K extends string>(node: Node, macro: K): node is TsPlusMacroCallExpression<K>
         isClassCompanionReference(node: Expression): boolean
         collectTsPlusFluentTags(statement: Declaration): readonly TsPlusJSDocExtensionTag[]
-        getFluentExtensionForPipeableSymbol(symbol: TsPlusPipeableSymbol): TsPlusFluentExtension | undefined
+        getFluentExtensionForPipeableSymbol(symbol: TsPlusPipeableIdentifierSymbol): TsPlusFluentExtension | undefined
         resolveCall(node: CallLikeExpression, signatures: readonly Signature[], candidatesOutArray: Signature[] | undefined, checkMode: CheckMode, callChainFlags: SignatureFlags, fallbackError?: DiagnosticMessage): Signature
     }
 

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -3406,6 +3406,18 @@ namespace ts {
         exportName: string;
     }
 
+    export interface TsPlusUnresolvedFluentExtensionDefinition {
+        declaration: (VariableDeclaration & { name: Identifier }) | FunctionDeclaration;
+        exportName: string;
+        definition: SourceFile;
+    }
+
+    export interface TsPlusUnresolvedFluentExtension {
+        definition: Set<TsPlusUnresolvedFluentExtensionDefinition>;
+        target: string;
+        name: string;
+    }
+
     export interface TsPlusStaticFunctionExtension {
         patched: Symbol;
         definition: SourceFile;
@@ -4619,6 +4631,7 @@ namespace ts {
         getIndexAccessExpressionCache(): ESMap<Node, { declaration: FunctionDeclaration, definition: SourceFile, exportName: string }>
         resolveStaticExtension(unresolved: TsPlusUnresolvedStaticExtension): Type | undefined
         getUnresolvedStaticExtension(targetType: Type, name: string): TsPlusUnresolvedStaticExtension | undefined
+        getUnresolvedFluentExtension(targetType: Type, name: string): TsPlusUnresolvedFluentExtension | undefined
         isTsPlusMacroCall<K extends string>(node: Node, macro: K): node is TsPlusMacroCallExpression<K>
         isClassCompanionReference(node: Expression): boolean
         collectTsPlusFluentTags(statement: Declaration): readonly TsPlusJSDocExtensionTag[]

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -4629,9 +4629,6 @@ namespace ts {
         getTextOfBinaryOp(kind: SyntaxKind): string | undefined
         getInstantiatedTsPlusSignature(declaration: Declaration, args: Expression[], checkMode: CheckMode | undefined): Signature
         getIndexAccessExpressionCache(): ESMap<Node, { declaration: FunctionDeclaration, definition: SourceFile, exportName: string }>
-        resolveStaticExtension(unresolved: TsPlusUnresolvedStaticExtension): Type | undefined
-        getUnresolvedStaticExtension(targetType: Type, name: string): TsPlusUnresolvedStaticExtension | undefined
-        getUnresolvedFluentExtension(targetType: Type, name: string): TsPlusUnresolvedFluentExtension | undefined
         isTsPlusMacroCall<K extends string>(node: Node, macro: K): node is TsPlusMacroCallExpression<K>
         isClassCompanionReference(node: Expression): boolean
         collectTsPlusFluentTags(statement: Declaration): readonly TsPlusJSDocExtensionTag[]

--- a/src/services/goToDefinition.ts
+++ b/src/services/goToDefinition.ts
@@ -105,7 +105,12 @@ namespace ts.GoToDefinition {
 
         // TSPLUS EXTENSION BEGIN
         let calledDeclaration = tryGetSignatureDeclaration(typeChecker, node);
-        if (calledDeclaration && calledDeclaration.symbol && isTsPlusSymbol(calledDeclaration.symbol) && calledDeclaration.symbol.tsPlusTag === TsPlusSymbolTag.PipeableMacro) {
+        if (
+            calledDeclaration &&
+            calledDeclaration.symbol &&
+            isTsPlusSymbol(calledDeclaration.symbol) &&
+            (calledDeclaration.symbol.tsPlusTag === TsPlusSymbolTag.PipeableMacro || calledDeclaration.symbol.tsPlusTag === TsPlusSymbolTag.PipeableDeclaration)
+        ) {
             // We have determined that this is a call of a Pipeable macro, which is a synthetic declaration (has no real position).
             // To go to the real definition, clear the callDeclaration to skip trying to get the definition info from the signature
             calledDeclaration = undefined;

--- a/src/services/signatureHelp.ts
+++ b/src/services/signatureHelp.ts
@@ -101,7 +101,7 @@ namespace ts.SignatureHelp {
                             untracedDeclaration,
                             resolvedSignature.typeParameters,
                             resolvedSignature.thisParameter,
-                            resolvedSignature.parameters.slice(0, declaration.parameters.length - 1),
+                            resolvedSignature.parameters.slice(0, resolvedSignature.parameters.length - 1),
                             resolvedSignature.getReturnType(),
                             resolvedSignature.resolvedTypePredicate,
                             resolvedSignature.minArgumentCount,


### PR DESCRIPTION
Closes #61 

This PR makes the resolution of fluent extensions lazy. Definitions are collected on init, and are resolved as needed by the checker. Also, I simplified the resolution of lazy static extensions. Instead of calling a separate function (`getUnresolvedStaticExtension`), and then resolving manually, the whole process is done in one shot when calling `getStaticValueExtension` or `getStaticFunctionExtension`.

Making the collection of fluent extensions lazy was done to resolve an issue that sometimes occurred when the type of a fluent extension depended on the type of another extension. If the extension that was depended on was not yet collected, a `property does not exist on type ...` error was reported.

Bugfixes:

- Pipeable fluent `goToDefinition`
- `checkPropertyAccessExpressionOrQualifiedName` not marking some identifiers as used
- Regression in hiding `__tsPlusTrace` from signatureHelp
- Allow macros on property access expressions