### PR TITLE
fix: resolve fluent extensions a bit more eagerly

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -44531,6 +44531,8 @@ namespace ts {
                 });
             });
 
+            fluentUnresolvedCache.clear();
+
             pipeableCache.forEach((map, typeName) => {
                 if (!fluentCache.has(typeName)) {
                     fluentCache.set(typeName, new Map());


### PR DESCRIPTION
The fully lazy resolution of fluent extensions was causing some to not be resolved properly before they were needed. This PR changes `initTsPlusChecker` to resolve fluent extensions after they are all collected. This ends up with a good compromise between lazy and eager resolution.