### PR TITLE
fix(transformer): don't transform as fluent if the signature is not fluent

### DIFF
--- a/effect/packages/package1/src/static-fluent-name-duplication.ts
+++ b/effect/packages/package1/src/static-fluent-name-duplication.ts
@@ -1,0 +1,23 @@
+/**
+ * @tsplus type static-fluent-name-duplication/A
+ * @tsplus companion static-fluent-name-duplication/AOps
+ */
+export class A {}
+
+/**
+ * @tsplus fluent static-fluent-name-duplication/A f
+ */
+export function fluentMethod(self: A, _x: number): A {
+  return self;
+}
+
+/**
+ * @tsplus static static-fluent-name-duplication/AOps f
+ */
+export function staticMethod(_y: string): A {
+  return new A();
+}
+
+A.f("hello");
+
+new A().f(1);

--- a/src/compiler/transformers/tsplus.ts
+++ b/src/compiler/transformers/tsplus.ts
@@ -397,8 +397,8 @@ namespace ts {
                         if (fluentExtension) {
                             let targetSignature: TsPlusSignature = fluentExtension.signatures[0];
 
+                            const resolvedSignature = checker.getResolvedSignature(node);
                             if (fluentExtension.signatures.length > 1) {
-                                const resolvedSignature = checker.getResolvedSignature(node);
                                 if (resolvedSignature) {
                                     // For signatures with type arguments, TsPlusSignature will be signature.target.
                                     // For signatures without type arguments, TsPlusSignature is the signature itself.
@@ -413,6 +413,10 @@ namespace ts {
 
                             if (!targetSignature || !isTsPlusSignature(targetSignature)) {
                                 throw new Error("BUG: No applicable signature found for fluent extension");
+                            }
+                            if (resolvedSignature && !resolvedSignature.thisParameter) {
+                                // We have a TsPlusSignature that is NOT a fluent signature, skip transforming as fluent
+                                return visitCallExpression(source, traceInScope, node, visitor, context);
                             }
                             const visited = visitCallExpression(source, traceInScope, node as CallExpression, visitor, context) as CallExpression;
                             if (targetSignature.tsPlusPipeable) {


### PR DESCRIPTION
Fixes a bug where, given a static and fluent extension on the same type with the same name, it was possible for the transformer to try to transform a static call as fluent.