### PR TITLE
feat: add support for primitive extensions

### DIFF
--- a/effect/packages/package1/src/primitives.ts
+++ b/effect/packages/package1/src/primitives.ts
@@ -1,0 +1,64 @@
+declare global {
+  /**
+   * @tsplus type string
+   */
+  export interface String {}
+  /**
+   * @tsplus type number
+   */
+  export interface Number {}
+  /**
+   * @tsplus type boolean
+   */
+  export interface Boolean {}
+  /**
+   * @tsplus type bigint
+   */
+  export interface BigInt {}
+  /**
+   * @tsplus type function
+   */
+  export interface Function {}
+  /**
+   * @tsplus type regexp
+   */
+  export interface RegExp {}
+}
+declare const a: string;
+declare const b: number;
+
+/**
+ * @tsplus getter string lines
+ */
+export function lines(self: string): string[] {
+  return self.split("\n");
+}
+
+const xs = a.lines;
+
+/**
+ * @tsplus fluent number days
+ */
+export function days(self: number, n: number): Date {
+  return new Date();
+}
+
+(0).days(1);
+
+/**
+ * @tsplus fluent function flow
+ */
+export function flow<A, B, C>(f: (a: A) => B, g: (b: B) => C): (a: A) => C {
+  return a => g(f(a));
+}
+
+const fn = ((x: number) => x.toString()).flow(s => parseInt(s));
+
+/**
+ * @tsplus fluent regexp testTwo
+ */
+export function testTwo(self: RegExp, that: RegExp): (s: string) => boolean {
+  return s => self.test(s) && that.test(s);
+}
+
+(/^$/).testTwo(/^$/)

--- a/effect/packages/package1/src/primitives.ts
+++ b/effect/packages/package1/src/primitives.ts
@@ -23,6 +23,10 @@ declare global {
    * @tsplus type regexp
    */
   export interface RegExp {}
+  /**
+   * @tsplus type object
+   */
+  export interface Object {}
 }
 declare const a: string;
 declare const b: number;
@@ -62,3 +66,35 @@ export function testTwo(self: RegExp, that: RegExp): (s: string) => boolean {
 }
 
 (/^$/).testTwo(/^$/)
+
+
+/**
+ * @tsplus type FunctionN
+ */
+export interface FunctionN<A extends readonly any[], B> {
+  (...params: A): B
+}
+
+/**
+ * @tsplus fluent FunctionN flow2
+ */
+export function flow2<A extends readonly any[], B, C>(self: FunctionN<A, B>, f: (b: B) => C): FunctionN<A, C> {
+  return (...params) => f(self(...params))
+}
+
+declare const ff: FunctionN<[string, number, boolean], string>
+
+ff.flow2((s) => parseInt(s))
+
+/**
+ * @tsplus fluent object mapObject
+ */
+export function mapObject<A, B>(self: Record<string, A>, f: (a: A) => B): Record<string, B> {
+  const r = {} as Record<string, B>
+  for (const k in self) {
+    r[k] = f(self[k])
+  }
+  return r
+}
+
+({ a: "hello" }).mapObject((s) => parseInt(s))

--- a/effect/packages/package1/src/primitives.ts
+++ b/effect/packages/package1/src/primitives.ts
@@ -76,7 +76,7 @@ export interface FunctionN<A extends readonly any[], B> {
 }
 
 /**
- * @tsplus fluent FunctionN flow2
+ * @tsplus fluent FunctionN flow
  */
 export function flow2<A extends readonly any[], B, C>(self: FunctionN<A, B>, f: (b: B) => C): FunctionN<A, C> {
   return (...params) => f(self(...params))
@@ -84,7 +84,7 @@ export function flow2<A extends readonly any[], B, C>(self: FunctionN<A, B>, f: 
 
 declare const ff: FunctionN<[string, number, boolean], string>
 
-ff.flow2((s) => parseInt(s))
+ff.flow((s) => parseInt(s))
 
 /**
  * @tsplus fluent object mapObject

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -368,11 +368,12 @@ namespace ts {
         const callCache = new Map<Node, TsPlusStaticFunctionExtension>();
         const indexCache = new Map<string, { declaration: FunctionDeclaration, definition: SourceFile, exportName: string }>();
         const indexAccessExpressionCache = new Map<Node, { declaration: FunctionDeclaration, definition: SourceFile, exportName: string }>();
-        let __tsplusStringSymbol: Symbol;
-        let __tsplusNumberSymbol: Symbol;
-        let __tsplusBooleanSymbol: Symbol;
-        let __tsplusBigIntSymbol: Symbol;
-        let __tsplusFunctionSymbol: Symbol;
+        let tsplusStringPrimitiveSymbol: Symbol;
+        let tsplusNumberPrimitiveSymbol: Symbol;
+        let tsplusBooleanPrimitiveSymbol: Symbol;
+        let tsplusBigIntPrimitiveSymbol: Symbol;
+        let tsplusFunctionPrimitiveSymbol: Symbol;
+        let tsplusObjectPrimitiveSymbol: Symbol;
         // TSPLUS EXTENSION END
 
         // Cancellation that controls whether or not we can cancel in the middle of type checking.
@@ -862,21 +863,6 @@ namespace ts {
         }
         function collectRelevantSymbols(target: Type) {
             const relevant: Set<Symbol> = new Set();
-            if (target.flags & TypeFlags.StringLike) {
-                relevant.add(__tsplusStringSymbol);
-            }
-            if (target.flags & TypeFlags.NumberLike) {
-                relevant.add(__tsplusNumberSymbol);
-            }
-            if (target.flags & TypeFlags.BooleanLike) {
-                relevant.add(__tsplusBooleanSymbol);
-            }
-            if (target.flags & TypeFlags.BigIntLike) {
-                relevant.add(__tsplusBigIntSymbol);
-            }
-            if (isFunctionType(target)) {
-                relevant.add(__tsplusFunctionSymbol);
-            }
             if (target.symbol) {
                 relevant.add(target.symbol);
             }
@@ -887,6 +873,25 @@ namespace ts {
             relevant.forEach((s) => {
                 returnArray.push(s)
             })
+            // collect primitive symbols last, in case they have overridden extensions
+            if (target.flags & TypeFlags.StringLike) {
+                returnArray.push(tsplusStringPrimitiveSymbol);
+            }
+            if (target.flags & TypeFlags.NumberLike) {
+                returnArray.push(tsplusNumberPrimitiveSymbol);
+            }
+            if (target.flags & TypeFlags.BooleanLike) {
+                returnArray.push(tsplusBooleanPrimitiveSymbol);
+            }
+            if (target.flags & TypeFlags.BigIntLike) {
+                returnArray.push(tsplusBigIntPrimitiveSymbol);
+            }
+            if (isFunctionType(target)) {
+                returnArray.push(tsplusFunctionPrimitiveSymbol);
+            }
+            if (target.flags & TypeFlags.Object) {
+                returnArray.push(tsplusObjectPrimitiveSymbol);
+            }
             return returnArray
         }
         function getExtensions(selfNode: Expression) {
@@ -954,7 +959,12 @@ namespace ts {
                             return []
                         }
                     )
-                    return x.length > 0 ? x[x.length - 1]() : undefined;
+                    if (x.length === 0) {
+                        continue;
+                    }
+                    else {
+                        return x[x.length - 1]();
+                    }
                 }
             }
         }
@@ -973,7 +983,12 @@ namespace ts {
                             return []
                         }
                     )
-                    return x.length > 0 ? x[x.length - 1] : undefined;
+                    if (x.length === 0) {
+                        continue;
+                    }
+                    else {
+                        return x[x.length - 1];
+                    }
                 }
             }
         }
@@ -992,7 +1007,12 @@ namespace ts {
                             return []
                         }
                     )
-                    return x.length > 0 ? x[x.length - 1] : undefined;
+                    if (x.length === 0) {
+                        continue;
+                    }
+                    else {
+                        return x[x.length - 1];
+                    }
                 }
             }
         }
@@ -1011,7 +1031,12 @@ namespace ts {
                             return []
                         }
                     )
-                    return x.length > 0 ? x[x.length - 1]() : undefined;
+                    if (x.length === 0) {
+                        continue;
+                    }
+                    else {
+                        return x[x.length - 1]();
+                    }
                 }
             }
         }
@@ -1030,7 +1055,12 @@ namespace ts {
                             return []
                         }
                     )
-                    return x.length > 0 ? x[x.length - 1]() : undefined;
+                    if (x.length === 0) {
+                        continue;
+                    }
+                    else {
+                        return x[x.length - 1]();
+                    }
                 }
             }
         }
@@ -1049,7 +1079,12 @@ namespace ts {
                             return []
                         }
                     )
-                    return x.length > 0 ? x[x.length - 1] : undefined;
+                    if (x.length === 0) {
+                        continue;
+                    }
+                    else {
+                        return x[x.length - 1];
+                    }
                 }
             }
         }
@@ -43964,19 +43999,22 @@ namespace ts {
                     return;
                 }
                 if (type === globalStringType) {
-                    addToTypeSymbolCache(__tsplusStringSymbol, typeTag, "after");
+                    addToTypeSymbolCache(tsplusStringPrimitiveSymbol, typeTag, "after");
                 }
                 if (type === globalNumberType) {
-                    addToTypeSymbolCache(__tsplusNumberSymbol, typeTag, "after");
+                    addToTypeSymbolCache(tsplusNumberPrimitiveSymbol, typeTag, "after");
                 }
                 if (type === globalBooleanType) {
-                    addToTypeSymbolCache(__tsplusBooleanSymbol, typeTag, "after");
+                    addToTypeSymbolCache(tsplusBooleanPrimitiveSymbol, typeTag, "after");
                 }
                 if (type === getGlobalBigIntType(false)) {
-                    addToTypeSymbolCache(__tsplusBigIntSymbol, typeTag, "after");
+                    addToTypeSymbolCache(tsplusBigIntPrimitiveSymbol, typeTag, "after");
                 }
                 if (type === globalFunctionType) {
-                    addToTypeSymbolCache(__tsplusFunctionSymbol, typeTag, "after");
+                    addToTypeSymbolCache(tsplusFunctionPrimitiveSymbol, typeTag, "after");
+                }
+                if (type === globalObjectType) {
+                    addToTypeSymbolCache(tsplusObjectPrimitiveSymbol, typeTag, "after");
                 }
                 if (type.symbol) {
                     addToTypeSymbolCache(type.symbol, typeTag, "after");
@@ -44423,11 +44461,12 @@ namespace ts {
             }
         }
         function initTsPlusTypeChecker() {
-            __tsplusStringSymbol = createSymbol(SymbolFlags.None, "string" as __String);
-            __tsplusNumberSymbol = createSymbol(SymbolFlags.None, "number" as __String);
-            __tsplusBooleanSymbol = createSymbol(SymbolFlags.None, "boolean" as __String);
-            __tsplusBigIntSymbol = createSymbol(SymbolFlags.None, "bigint" as __String);
-            __tsplusFunctionSymbol = createSymbol(SymbolFlags.None, "function" as __String);
+            tsplusStringPrimitiveSymbol = createSymbol(SymbolFlags.None, "string" as __String);
+            tsplusNumberPrimitiveSymbol = createSymbol(SymbolFlags.None, "number" as __String);
+            tsplusBooleanPrimitiveSymbol = createSymbol(SymbolFlags.None, "boolean" as __String);
+            tsplusBigIntPrimitiveSymbol = createSymbol(SymbolFlags.None, "bigint" as __String);
+            tsplusFunctionPrimitiveSymbol = createSymbol(SymbolFlags.None, "function" as __String);
+            tsplusObjectPrimitiveSymbol = createSymbol(SymbolFlags.None, "object" as __String);
             fluentCache.clear();
             unresolvedFluentCache.clear();
             operatorCache.clear();

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -4640,6 +4640,7 @@ namespace ts {
         isClassCompanionReference(node: Expression): boolean
         collectTsPlusFluentTags(statement: Declaration): readonly TsPlusJSDocExtensionTag[]
         getFluentExtensionForPipeableSymbol(symbol: TsPlusPipeableIdentifierSymbol): TsPlusFluentExtension | undefined
+        getPrimitiveTypeName(type: Type): string | undefined
     }
 
     /* @internal */

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -1776,7 +1776,7 @@ namespace ts {
                         tsPlusSymbol = type.tsPlusSymbol;
                     }
                     if(tsPlusSymbol) {
-                        let thisTypeName = getThisTypeNameForTsPlusSymbol(tsPlusSymbol)
+                        let thisTypeName = getThisTypeNameForTsPlusSymbol(typeChecker, tsPlusSymbol)
                         if (nodeForQuickInfo.parent && nodeForQuickInfo.parent.parent) {
                             thisTypeName = getThisTypeNameForCallLikeExpression(typeChecker, nodeForQuickInfo.parent.parent) ?? thisTypeName
                         }


### PR DESCRIPTION
This PR adds support for extensions on the following primitive types:

- `String`
- `Number`
- `Boolean`
- `BigInt`
- `Function`
- `Object`

In addition, it adds a very simple form of inheriting/overriding extensions, such that if a type that extends a primitive type (e.g. `FunctionN`) defines its own extension that overrides an extension on a primitive (e.g. `flow`), the extension from the non-primitive will be chosen.