### PR TITLE
fix: add union inheritance

### DIFF
--- a/effect/packages/package1/src/union-inheritance.ts
+++ b/effect/packages/package1/src/union-inheritance.ts
@@ -1,0 +1,91 @@
+/**
+ * @tsplus type union/Cons
+ */
+export class Cons<A> implements Iterable<A> {
+  readonly _tag = "Cons";
+  constructor(readonly head: A, readonly tail: List<A>) {}
+  // @ts-expect-error
+  [Symbol.iterator]() {}
+}
+
+/**
+ * @tsplus type union/Nil
+ */
+export class Nil<A> implements Iterable<A> {
+  readonly _tag = "Nil";
+  // @ts-expect-error
+  [Symbol.iterator]() {}
+}
+
+/**
+ * @tsplus type union/List
+ */
+export type List<A> = Cons<A> | Nil<A>;
+
+/**
+ * @tsplus fluent union/List map
+ */
+export declare function mapList<A, B>(list: List<A>, f: (a: A) => B): List<B>;
+
+declare const x: List<string>;
+
+function transformTest() {
+  x.map(s => s);
+}
+
+/**
+ * @tsplus type union/A
+ */
+export interface A {
+  readonly _A: unique symbol;
+}
+
+/**
+ * @tsplus type union/B
+ */
+export interface B {
+  readonly _B: unique symbol;
+}
+
+/**
+ * @tsplus type union/C
+ */
+export interface C extends A {
+  readonly _C: unique symbol;
+}
+
+/**
+ * @tsplus type union/D
+ */
+export interface D extends A, B {
+  readonly _D: unique symbol;
+}
+
+/**
+ * @tsplus type union/E
+ */
+export type E = C | D;
+
+/**
+ * @tsplus fluent union/A methodA
+ */
+export declare function methodA(self: A): void;
+
+/**
+ * @tsplus fluent union/B methodB
+ */
+export declare function methodB(self: B): void;
+
+/**
+ * @tsplus fluent union/E methodE
+ */
+export declare function methodE(self: E): void;
+
+declare const e: E;
+
+function subtypeTest() {
+  e.methodE();
+  e.methodA();
+  // @ts-expect-error
+  e.methodB();
+}

--- a/effect/packages/package1/src/union-inheritance.ts
+++ b/effect/packages/package1/src/union-inheritance.ts
@@ -89,3 +89,48 @@ function subtypeTest() {
   // @ts-expect-error
   e.methodB();
 }
+
+// alias inheritance
+
+/**
+ * @tsplus type union/AA
+ */
+export interface AA {
+  readonly _AA: unique symbol;
+}
+
+/**
+ * @tsplus type union/AB
+ */
+export interface AB extends AA {
+  readonly _AB: unique symbol;
+}
+
+/**
+ * @tsplus type union/AC
+ */
+export type AC = AA
+
+export type AD = AC | AB
+
+/**
+ * @tsplus fluent union/AA methodAA
+ */
+export declare function methodAA(self: AA): void
+/**
+ * @tsplus fluent union/AB methodAB
+ */
+export declare function methodAB(self: AB): void
+/**
+ * @tsplus fluent union/AC methodAC
+ */
+export declare function methodAC(self: AC): void
+
+declare const ac: AD
+
+function aliasTest() {
+  ac.methodAA()
+  // @ts-expect-error
+  ac.methodAB()
+  ac.methodAC()
+}

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -897,8 +897,8 @@ namespace ts {
 
             return out;
         }
-        function collectRelevantSymbolsLoop(target: Type) {
-            const seen: Set<Type> = new Set();
+        function collectRelevantSymbolsLoop(target: Type, lastSeen?: Set<Type>) {
+            const seen: Set<Type> = new Set(lastSeen);
             const relevant: Set<Symbol> = new Set();
             let stack: Stack<Type> | undefined = makeStack(target);
             while (stack) {
@@ -925,9 +925,12 @@ namespace ts {
                         const inherited: Set<Symbol>[] = []
                         for (const member of types) {
                             if (!seen.has(member)) {
-                                seen.add(member);
-                                inherited.push(collectRelevantSymbolsLoop(member));
+                                inherited.push(collectRelevantSymbolsLoop(member, seen));
                             }
+                        }
+                        // Add union members as "seen" only after the union has been collected
+                        for (const member of types) {
+                            seen.add(member);
                         }
                         intersectSets(inherited).forEach((s) => {
                             relevant.add(s)


### PR DESCRIPTION
This PR adds union inheritance collection functionality to `collectRelevantSymbols`.