### PR TITLE
chore: use tsplus in release string; allow nightly features

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -596,9 +596,9 @@ const configureExperimental = () => exec(process.execPath, ["scripts/configurePr
 task("configure-experimental", series(buildScripts, configureExperimental));
 task("configure-experimental").description = "Runs scripts/configurePrerelease.ts to prepare a build for experimental publishing";
 
-const configureEts = () => exec(process.execPath, ["scripts/configurePrerelease.js", "ets", "package.json", "src/compiler/corePublic.ts"]);
-task("configure-ets", series(buildScripts, configureEts));
-task("configure-ets").description = "Runs scripts/configurePrerelease.ts to prepare a build for ets publishing";
+const configureTsplus = () => exec(process.execPath, ["scripts/configurePrerelease.js", "tsplus", "package.json", "src/compiler/corePublic.ts"]);
+task("configure-tsplus", series(buildScripts, configureTsplus));
+task("configure-tsplus").description = "Runs scripts/configurePrerelease.ts to prepare a build for tsplus publishing";
 
 const createLanguageServicesBuild = () => exec(process.execPath, ["scripts/createLanguageServicesBuild.js"]);
 task("create-language-services-build", series(buildScripts, createLanguageServicesBuild));

--- a/pack.sh
+++ b/pack.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 npm ci
 npm run postprepare
-npm run gulp configure-ets
+npm run gulp configure-tsplus
 npm run gulp LKG
 npm run gulp clean
 npm pack

--- a/scripts/configurePrerelease.ts
+++ b/scripts/configurePrerelease.ts
@@ -17,12 +17,12 @@ function main(): void {
     if (args.length < 3) {
         const thisProgramName = relative(process.cwd(), __filename);
         console.log("Usage:");
-        console.log(`\tnode ${thisProgramName} <dev|insiders|ets> <package.json location> <file containing version>`);
+        console.log(`\tnode ${thisProgramName} <dev|insiders|tsplus> <package.json location> <file containing version>`);
         return;
     }
 
     const tag = args[0];
-    if (tag !== "dev" && tag !== "insiders" && tag !== "experimental" && tag !== "ets") {
+    if (tag !== "dev" && tag !== "insiders" && tag !== "experimental" && tag !== "tsplus") {
         throw new Error(`Unexpected tag name '${tag}'.`);
     }
 

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -3335,7 +3335,7 @@ namespace ts {
         }
 
         function verifyCompilerOptions() {
-            const isNightly = stringContains(version, "-dev") || stringContains(version, "-insiders");
+            const isNightly = stringContains(version, "-dev") || stringContains(version, "-insiders") || stringContains(version, "-tsplus");
             if (!isNightly) {
                 if (getEmitModuleKind(options) === ModuleKind.Node12) {
                     createOptionValueDiagnostic("module", Diagnostics.Compiler_option_0_of_value_1_is_unstable_Use_nightly_TypeScript_to_silence_this_error_Try_updating_with_npm_install_D_typescript_next, "module", "node12");


### PR DESCRIPTION
This PR changes the release string from `ets` to `tsplus`, as well as allows the use of nightly features (e.g. `moduleResolution: "Node12"`