### PR TITLE
chore: restrict fluent extensions to assignable targets

### DIFF
--- a/effect/packages/package1/src/index.ts
+++ b/effect/packages/package1/src/index.ts
@@ -68,6 +68,31 @@ export function arrayHead<A>(self: Array<A>): A | undefined {
 
 const a = [1, 2, 3].map0((a) => a).getter.map0((a) => a).getter.head
 
+
+/**
+ * @tsplus fluent Array sum
+ */
+export function sum<T extends number>(self: Array<T>): number {
+  return self.reduce((prev, cur) => prev + cur, 0)
+}
+
+/**
+* @tsplus getter Array getSum
+*/
+export function getSum<T extends number>(self: Array<T>): number {
+  return self.reduce((prev, cur) => prev + cur, 0)
+}
+
+/**
+* @tsplus fluent Array average
+*/
+export function average(self: Array<number>): number {
+  return self.sum() / self.length
+}
+
+export const arrAvg = [0, 1].average();
+export const arrSum = [0, 1].sum();
+
 const x2 = Effect(0)
 
 function baseConstraint<A extends Array<unknown>>(...xs: A): unknown[] {
@@ -121,3 +146,5 @@ const zzz2 = Effect.succeed(() => zzz)
 
 // @ts-expect-error
 const zzz3 = Effect.succeed(zzz)
+
+Effect.do.bind("0", () => Effect(0)).bind("1", () => Effect(1))

--- a/effect/packages/package1/src/prelude/operations/bind.ts
+++ b/effect/packages/package1/src/prelude/operations/bind.ts
@@ -8,7 +8,7 @@ import { Effect } from "../definition/Effect.js"
  *
  * @tsplus fluent ets/Effect bind
  */
-export function bind_<R2, E2, R, E, A, K, N extends string>(self: Effect<R2, E2, K>, tag: Exclude<N, keyof K>, f: (_: K) => Effect<R, E, A>, __tsplusTrace?: string): Effect<R & R2, E | E2, Flat<K & {
+export function bind_<R2, E2, R, E, A, K extends Record<string, unknown>, N extends string>(self: Effect<R2, E2, K>, tag: Exclude<N, keyof K>, f: (_: K) => Effect<R, E, A>, __tsplusTrace?: string): Effect<R & R2, E | E2, Flat<K & {
     [k in N]: A
 }>> {
     // @ts-expect-error

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -1021,7 +1021,16 @@ namespace ts {
                                 }
                                 const extension = v()
                                 if (extension) {
-                                    copy.set(k, extension.patched);
+                                    const isValidTarget = getSignaturesOfType(getTypeOfSymbol(extension.patched), SignatureKind.Call).find((s) => {
+                                        const base = getBaseSignature(s);
+                                        if (base.thisParameter) {
+                                            return isTypeAssignableTo(targetType, getTypeOfSymbol(base.thisParameter));
+                                        }
+                                        return false;
+                                    });
+                                    if (isValidTarget) {
+                                        copy.set(k, extension.patched);
+                                    }
                                 }
                             });
                         }


### PR DESCRIPTION
Hopefully it isn't too intensive on the checker, closes https://github.com/ts-plus/typescript/issues/63