### PR TITLE
fix: `goToDefinition` for fluent extension expressions

### DIFF
--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -3464,7 +3464,8 @@ namespace ts {
         tsPlusTag: "TsPlusSignature";
         tsPlusFile: SourceFile;
         tsPlusExportName: string;
-        tsPlusPipeable?: boolean
+        tsPlusDeclaration?: Declaration;
+        tsPlusPipeable?: boolean;
     }
 
     export interface JSDocLink extends Node {

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -1854,13 +1854,20 @@ namespace ts {
                                     break;
                                 }
                                 displayParts = displayParts.concat(getTsPlusSignatureDisplayParts(typeChecker, nodeForQuickInfo, declaration, resolvedSignature));
+                                let tsPlusDeclaration = getDeclarationForTsPlus(typeChecker, node.parent.parent, tsPlusSymbol);
+
+                                let declarations: Declaration[] = [declaration]
+                                if (tsPlusDeclaration && tsPlusDeclaration !== declaration) {
+                                    declarations.push(tsPlusDeclaration)
+                                }
+
                                 return {
                                     kind: ScriptElementKind.memberFunctionElement,
                                     kindModifiers: ScriptElementKindModifier.staticModifier,
                                     textSpan: createTextSpanFromNode(nodeForQuickInfo, sourceFile),
                                     displayParts,
-                                    documentation: getDocumentationComment([declaration], typeChecker),
-                                    tags: getJsDocTagsOfDeclarations([declaration], typeChecker)
+                                    documentation: getDocumentationComment(declarations, typeChecker),
+                                    tags: getJsDocTagsOfDeclarations(declarations, typeChecker)
                                 };
                             }
                             case TsPlusSymbolTag.StaticFunction: {


### PR DESCRIPTION
Closes #81 
![2022-03-17 23 02 16](https://user-images.githubusercontent.com/20319430/158930740-d2c6e29e-1452-4131-a3de-6102cbf6f10a.gif)

