### PR TITLE
fix: give local extensions unique names

### DIFF
--- a/effect/packages/package1/src/scope-name-conflict.ts
+++ b/effect/packages/package1/src/scope-name-conflict.ts
@@ -1,0 +1,25 @@
+/**
+ * @tsplus type scope-name-conflict/A
+ * @tsplus companion scope-name-conflict/AOps
+ */
+export class A {
+  constructor(readonly conflict: string) {}
+}
+
+/**
+ * @tsplus static scope-name-conflict/AOps conflict
+ */
+export function conflict(s: string): A {
+  return new A(s)
+}
+
+function test() {
+  A.x;
+  const conflict = "name conflict"
+  A.conflict(conflict)
+}
+
+/**
+ * @tsplus static scope-name-conflict/AOps x
+ */
+export const x = new A("thing")


### PR DESCRIPTION
This PR covers the simplest implementation for solving #62: just create a uniquely-named declaration for each extension, and use than name when referring to the extension if the reference is in the same file in which the extension is declared.