### PR TITLE
fix: mark fluent and getter left nodes as referenced

### DIFF
--- a/effect/packages/package1/src/import-bug/1.ts
+++ b/effect/packages/package1/src/import-bug/1.ts
@@ -1,0 +1,3 @@
+import { Effect } from "../prelude";
+
+export const anEffect = Effect.succeed(0)

--- a/effect/packages/package1/src/import-bug/2.ts
+++ b/effect/packages/package1/src/import-bug/2.ts
@@ -1,0 +1,4 @@
+import { Effect } from "../prelude";
+import { anEffect } from "./1";
+
+export const y = anEffect.flatMap((x) => Effect.succeed(x + 1))

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -29585,6 +29585,9 @@ namespace ts {
                 const fluentExt = getFluentExtension(leftType, right.escapedText.toString())
                 if (fluentExt && isCallExpression(node.parent) && node.parent.expression === node) {
                     if (isExtensionValidForTarget(fluentExt, leftType)) {
+                        if (isIdentifier(_left)) {
+                            markAliasReferenced(getResolvedSymbol(_left), _left);
+                        }
                         return getTypeOfSymbol(fluentExt.patched)
                     }
                     return;
@@ -29593,6 +29596,9 @@ namespace ts {
                 if (getterExt && isExpression(_left)) {
                     const symbol = getterExt.patched(_left);
                     if (symbol) {
+                        if (isIdentifier(_left)) {
+                            markAliasReferenced(getResolvedSymbol(_left), _left);
+                        }
                         const type = getTypeOfSymbol(symbol);
                         // @ts-expect-error
                         type.tsPlusSymbol = symbol; // TsPlusGetterSymbol | TsPlusGetterVariableSymbol


### PR DESCRIPTION
This PR fixes an issue where imports that were used in a fluent or getter expression would be erased. See the demo case for an example.