### PR TITLE
Revert inheritance changes

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -921,17 +921,6 @@ namespace ts {
                         const heritage = inheritanceSymbolCache.get(target.symbol)!;
                         heritage.forEach(addInheritedSymbol);
                     }
-                    else if (target.symbol.declarations) {
-                        target.symbol.declarations.forEach((declaration) => {
-                            if ((isInterfaceDeclaration(declaration) || isClassDeclaration(declaration)) && declaration.heritageClauses) {
-                                tryCacheTsPlusInheritance(target.symbol, declaration.heritageClauses);
-                                if (inheritanceSymbolCache.has(target.symbol)) {
-                                    const heritage = inheritanceSymbolCache.get(target.symbol)!;
-                                    heritage.forEach(addInheritedSymbol);
-                                }
-                            }
-                        })
-                    }
                 }
                 if (target.aliasSymbol) {
                     relevant.add(target.aliasSymbol);


### PR DESCRIPTION
Taking all the types for each declaration of a symbol ends up including unrelated tags, for example in Hash getting the declarations of the symbol Hash will return both the Hash interface and the Hash term defined via const, the Hash term has type HashOps