### PR TITLE
fix: don't inherit from identically named symbol

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -954,7 +954,6 @@ namespace ts {
                         }
                         intersectSets(inherited).forEach((s) => {
                             relevant.add(s)
-                            stack = makeStack(getTypeOfSymbol(s), stack);
                         })
                     }
                 }


### PR DESCRIPTION
Fixed this bug:

#93 

>Taking all the types for each declaration of a symbol ends up including unrelated tags, for example in Hash getting the declarations of the symbol Hash will return both the Hash interface and the Hash term defined via const, the Hash term has type HashOps
