### PR TITLE
fix: use type flags to get primitive type name

### DIFF
--- a/effect/packages/package1/src/primitives.ts
+++ b/effect/packages/package1/src/primitives.ts
@@ -29,7 +29,6 @@ declare global {
   export interface Object {}
 }
 declare const a: string;
-declare const b: number;
 
 /**
  * @tsplus getter string lines
@@ -41,13 +40,13 @@ export function lines(self: string): string[] {
 const xs = a.lines;
 
 /**
- * @tsplus fluent number days
+ * @tsplus getter number days
  */
 export function days(self: number, n: number): Date {
   return new Date();
 }
 
-(0).days(1);
+(0).days
 
 /**
  * @tsplus fluent function flow

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -835,16 +835,16 @@ namespace ts {
 
         // TSPLUS EXTENSION BEGIN
         function getPrimitiveTypeName(type: Type): string | undefined {
-            if (type === stringType) {
+            if (type.flags & TypeFlags.StringLike) {
                 return "String";
             }
-            if (type === numberType) {
+            if (type.flags & TypeFlags.NumberLike) {
                 return "Number";
             }
-            if (type === booleanType) {
+            if (type.flags & TypeFlags.BooleanLike) {
                 return "Boolean";
             }
-            if (type === bigintType) {
+            if (type.flags & TypeFlags.BigIntLike) {
                 return "BigInt";
             }
         }


### PR DESCRIPTION
Fixes an issue where primitive type names would not be displayed correctly when hovering.

<img width="280" alt="Screen Shot 2022-03-23 at 12 12 30 AM" src="https://user-images.githubusercontent.com/20319430/159622489-1dead47c-2a96-4841-8a6d-230fa75bbdea.png">
