### PR TITLE
chore: consider all project files as modules

### DIFF
--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -64,8 +64,9 @@ namespace ts {
     export function isFileProbablyExternalModule(sourceFile: SourceFile) {
         // Try to use the first top-level import/export when available, then
         // fall back to looking for an 'import.meta' somewhere in the tree if necessary.
-        return forEach(sourceFile.statements, isAnExternalModuleIndicatorNode) ||
-            getImportMetaIfNecessary(sourceFile);
+        // TSPLUS EXTENSION BEGIN
+        return sourceFile.isDeclarationFile ? (forEach(sourceFile.statements, isAnExternalModuleIndicatorNode) || getImportMetaIfNecessary(sourceFile)) : true;
+        // TSPLUS EXTENSION END
     }
 
     function isAnExternalModuleIndicatorNode(node: Node) {


### PR DESCRIPTION
For TS+ any file is a module as TS+ may freely add imports to every file