### PR TITLE
fix: set static symbol declared type to original declared type

### DIFF
--- a/effect/packages/package1/src/type-and-static-repro/1.ts
+++ b/effect/packages/package1/src/type-and-static-repro/1.ts
@@ -1,0 +1,39 @@
+/**
+ * @tsplus type type-and-static/A
+ */
+ export interface A {}
+
+ /**
+  * @tsplus type type-and-static/AOps
+  */
+ export interface AOps {}
+ 
+ export const A: AOps = {}
+ 
+ /**
+  * @tsplus type type-and-static/AAspects
+  */
+ export interface AAspects {}
+ 
+ /**
+  * @tsplus static type-and-static/AOps $
+  */
+ export const AAspects: AAspects = {}
+ 
+ /**
+  * @tsplus static type-and-static/AOps staticFn
+  * @tsplus static type-and-static/AAspects staticFn
+  */
+ export function staticFn(x: number): void {}
+ 
+ /**
+  * @tsplus static type-and-static/AOps staticConstFn
+  * @tsplus static type-and-static/AAspects staticConstFn
+  */
+ export declare const staticConstFn: (x: number) => void
+
+ A.staticFn(1)
+ A.staticConstFn(1)
+ 
+ A.$.staticFn(1)
+ A.$.staticConstFn(1)

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -45562,6 +45562,7 @@ namespace ts {
             const originalSymbolLinks = getSymbolLinks(originalSymbol);
             const symbolLinks = getSymbolLinks(symbol);
             symbolLinks.uniqueESSymbolType = originalSymbolLinks.uniqueESSymbolType;
+            symbolLinks.declaredType = originalSymbolLinks.declaredType;
 
             return symbol;
         }


### PR DESCRIPTION
Fixes statics that are named the same as their declared type, if that type is also annotated as `@tsplus type`.

For example, this didn't used to work:

```ts

/**
 * @tsplus type type-and-static/A
 */
 export interface A {}

 /**
  * @tsplus type type-and-static/AOps
  */
 export interface AOps {}

 export const A: AOps = {}

 /**
  * @tsplus type type-and-static/AAspects
  */
 export interface AAspects {}

 /**
  * @tsplus static type-and-static/AOps $
  */
 export const AAspects: AAspects = {}
              // ^ Circular reference error would be here

 A.$ // <-- Would cause an error

```