### PR TITLE
chore: fix watch mode

### DIFF
--- a/src/compiler/builderState.ts
+++ b/src/compiler/builderState.ts
@@ -224,6 +224,12 @@ namespace ts {
                 }
             }
 
+            // TSPLUS START
+            for (const file of arrayFrom(program.getTypeChecker().getTsPlusFiles().values())) {
+                addReferencedFile(file.resolvedPath);
+            }
+            // TSPLUS END
+
             // From ambient modules
             for (const ambientModule of program.getTypeChecker().getAmbientModules()) {
                 if (ambientModule.declarations && ambientModule.declarations.length > 1) {

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -4963,6 +4963,8 @@ namespace ts {
         getPrimitiveTypeName(type: Type): string | undefined
         getResolvedOperator(node: BinaryExpression): Signature | undefined
         getNodeLinks(node: Node): NodeLinks
+        // TSPLUS START
+        getTsPlusFiles(): Set<SourceFile>
         collectTsPlusMacroTags(statement: Declaration): readonly string[]
         getTsPlusGlobals(): Symbol[];
         getTsPlusGlobal(name: string): TsPlusGlobalImport | undefined;
@@ -4970,6 +4972,7 @@ namespace ts {
         getTsPlusExtensionsAtLocation(node: Node): TsPlusExtensionTag[];
         getTsPlusSymbolAtLocation(node: Node): TsPlusSymbol | undefined;
         getExtensionsForDeclaration(node: Declaration): TsPlusExtensionTag[]
+        // TSPLUS END
     }
 
     /* @internal */


### PR DESCRIPTION
First step of having incremental and watch mode working fine, at the moment I treat every file that contains any ts+ definition like a global file referenced by any other file.

This while it should work it may be triggering too much recompilation, a better approach would be better to track in the checker which files extends what and only track imported scope, basically:

1: each file is processed in init, we detect A extends B if A has an extension declared in B
2: when adding referenced files we add 1 global imports (maybe used) and 2 (directly referenced imports(
