### PR TITLE
feat: add no-inherit pragma

### DIFF
--- a/effect/packages/package1/src/no-inherit.ts
+++ b/effect/packages/package1/src/no-inherit.ts
@@ -1,0 +1,24 @@
+/**
+ * @tsplus type no-inherit/A
+ */
+export interface A<X> {
+  readonly _X: X
+}
+
+/**
+ * @tsplus type no-inherit/B
+ * @tsplus no-inherit no-inherit/A
+ */
+export type B<X> = A<A<X>>
+
+/**
+ * @tsplus fluent no-inherit/A fnA
+ */
+export declare function fnA<X>(_: A<X>): A<X>
+
+/**
+ * @tsplus fluent no-inherit/B fnB
+ */
+export declare function fnB<X>(_: B<X>): B<X>
+
+declare const b: B<string>

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -7514,6 +7514,10 @@
         "category": "Error",
         "code": 50023
     },
+    "Annotation of a no-inherit extension must have the form '@tsplus no-inherit [typename]": {
+        "category": "Error",
+        "code": 50024
+    },
     "A call to bind is only allowed in the context of a Do.": {
         "category": "Error",
         "code": 51000

--- a/src/compiler/factory/nodeFactory.ts
+++ b/src/compiler/factory/nodeFactory.ts
@@ -5309,6 +5309,7 @@ namespace ts {
             node.tsPlusContext = {
                 type: [],
                 companion: [],
+                noInherit: [],
                 fluent: [],
                 pipeable: [],
                 operator: [],
@@ -5317,7 +5318,7 @@ namespace ts {
                 static: [],
                 getter: [],
                 unify: [],
-                index: []
+                index: [],
             }
             return node;
         }

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -3065,9 +3065,10 @@ namespace ts {
         /** May be undefined in `export default class { ... }`. */
         readonly name?: Identifier;
         // TSPLUS START
-        readonly tsPlusTypeTags?: string[]
-        readonly tsPlusCompanionTags?: string[]
-        readonly tsPlusDeriveTags?: string[]
+        readonly tsPlusTypeTags?: string[];
+        readonly tsPlusCompanionTags?: string[];
+        readonly tsPlusDeriveTags?: string[];
+        readonly tsPlusNoInheritTags?: string[];
         // TSPLUS END
     }
 
@@ -3104,8 +3105,9 @@ namespace ts {
         /* @internal */ readonly decorators?: NodeArray<Decorator> | undefined;
         
         // TSPLUS BEGIN
-        readonly tsPlusTypeTags?: string[]
-        readonly tsPlusDeriveTags?: string[]
+        readonly tsPlusTypeTags?: string[];
+        readonly tsPlusDeriveTags?: string[];
+        readonly tsPlusNoInheritTags?: string[];
         // TSPLUS END
     }
 
@@ -3127,7 +3129,8 @@ namespace ts {
         /* @internal */ readonly decorators?: NodeArray<Decorator> | undefined;
 
         // TSPLUS BEGIN
-        readonly tsPlusTypeTags?: string[]
+        readonly tsPlusTypeTags?: string[];
+        readonly tsPlusNoInheritTags?: string[];
         // TSPLUS END
     }
 
@@ -4198,6 +4201,7 @@ namespace ts {
             unify: FunctionDeclaration[];
             index: (VariableDeclarationWithIdentifier | FunctionDeclaration)[];
             pipeableIndex: (VariableDeclarationWithIdentifier | FunctionDeclaration)[];
+            noInherit: (InterfaceDeclaration | TypeAliasDeclaration | ClassDeclaration)[];
         }
         // TSPLUS EXTENSION END
     }


### PR DESCRIPTION
The `@tsplus no-inherit` pragma allows the user to exclude certain type tags from a type's inheritance tree.